### PR TITLE
Add central deployment script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,113 @@
 # instavibe-bootstrap
 
-## Agent Deployment
+This repository contains the necessary scripts and configurations to deploy the Instavibe application and its associated agents and services.
+
+## Central Deployment Script (`deploy_all.py`)
+
+A central Python script `deploy_all.py` is provided in the root directory to orchestrate the deployment of all components.
+
+### Prerequisites
+
+Before running the central deployment script, ensure you have the following:
+
+1.  **Google Cloud SDK (`gcloud`)**: Installed and authenticated. You can find installation instructions [here](https://cloud.google.com/sdk/docs/install).
+    *   Ensure you have logged in (`gcloud auth login`) and set your project (`gcloud config set project [YOUR_PROJECT_ID]`).
+2.  **Python 3**: Installed on your system.
+3.  **Docker**: Installed and running on your system, if you are deploying the Dockerized services. The script will use `docker` commands to build and push images. (Alternatively, Google Cloud Build can be used as described in the manual section, which doesn't require local Docker for the build step).
+4.  **Project ID**: Your Google Cloud Project ID.
+5.  **Region**: The Google Cloud region where you want to deploy the services (e.g., `us-central1`).
+
+### Usage
+
+Navigate to the root directory of this repository and run the script as follows:
+
+```bash
+python deploy_all.py --project_id [YOUR_PROJECT_ID] --region [YOUR_REGION]
+```
+
+**Optional Flags:**
+
+You can skip deploying certain parts of the application using the following flags:
+
+*   `--skip_agents`: Skips the deployment of the Planner, Social, and Orchestrate agents.
+*   `--skip_app`: Skips the deployment of the Instavibe App.
+*   `--skip_platform_mcp_client`: Skips the deployment of the Platform MCP Client.
+*   `--skip_mcp_tool_server`: Skips the deployment of the MCP Tool Server.
+
+**Example:**
+
+To deploy only the Instavibe App and the MCP Tool Server:
+
+```bash
+python deploy_all.py --project_id my-gcp-project --region us-central1 --skip_agents --skip_platform_mcp_client
+```
+
+## Manual Deployment
+
+If you prefer to deploy components individually, follow the instructions below.
+
+### Agents (Planner, Social, Orchestrate)
+
+These agents are designed for deployment to Google Cloud Vertex AI Agent Engine.
+
+1.  **Planner Agent:**
+    *   Navigate to the agent's directory: `cd agents/planner`
+    *   Run the deployment script: `python deploy.py --project_id [YOUR_PROJECT_ID] --region [YOUR_REGION]`
+    *   The script will guide you through the deployment process.
+
+2.  **Social Agent:**
+    *   Navigate to the agent's directory: `cd agents/social`
+    *   Run the deployment script: `python deploy.py --project_id [YOUR_PROJECT_ID] --region [YOUR_REGION]`
+    *   The script will guide you through the deployment process.
+
+3.  **Orchestrate Agent:**
+    *   Navigate to the agent's directory: `cd agents/orchestrate`
+    *   Run the deployment script: `python deploy.py --project_id [YOUR_PROJECT_ID] --region [YOUR_REGION]`
+    *   The script will guide you through the deployment process.
+
+### Dockerized Services (Instavibe App, Platform MCP Client, MCP Tool Server)
+
+These services are deployed as Docker containers to Google Cloud Run.
+
+**General Steps:**
+
+For each service:
+
+1.  **Build the Docker image using Google Cloud Build:**
+    ```bash
+    gcloud builds submit --tag gcr.io/[PROJECT_ID]/[SERVICE_NAME] [SERVICE_DIRECTORY]
+    ```
+    Replace `[PROJECT_ID]` with your Google Cloud Project ID, `[SERVICE_NAME]` with the specific service name (e.g., `instavibe-app`), and `[SERVICE_DIRECTORY]` with the path to the directory containing the Dockerfile.
+
+2.  **Deploy the image to Cloud Run:**
+    ```bash
+    gcloud run deploy [SERVICE_NAME] \
+      --image gcr.io/[PROJECT_ID]/[SERVICE_NAME] \
+      --platform managed \
+      --region [REGION] \
+      --project [PROJECT_ID] \
+      --allow-unauthenticated
+    ```
+    Replace `[PROJECT_ID]`, `[SERVICE_NAME]`, and `[REGION]` accordingly. The `--allow-unauthenticated` flag makes the service publicly accessible; adjust as needed for your security requirements.
+
+**Service-Specific Information:**
+
+1.  **Instavibe App:**
+    *   Service Name: `instavibe-app` (or your preferred name)
+    *   Service Directory (contains Dockerfile): `instavibe/`
+    *   Dockerfile Location: `instavibe/Dockerfile`
+
+2.  **Platform MCP Client:**
+    *   Service Name: `platform-mcp-client` (or your preferred name)
+    *   Service Directory (contains Dockerfile): `agents/platform_mcp_client/`
+    *   Dockerfile Location: `agents/platform_mcp_client/Dockerfile`
+
+3.  **MCP Tool Server:**
+    *   Service Name: `mcp-tool-server` (or your preferred name)
+    *   Service Directory (contains Dockerfile): `tools/instavibe/`
+    *   Dockerfile Location: `tools/instavibe/Dockerfile`
+
+## Original Agent Deployment Note
 
 The Planner, Social, and Orchestrate agents are designed for deployment to Google Cloud Vertex AI Agent Engine. Each of these agents includes a `deploy.py` script in its respective directory (`agents/<agent_name>/deploy.py`) to facilitate this deployment.
 

--- a/deploy_all.py
+++ b/deploy_all.py
@@ -1,0 +1,253 @@
+import subprocess
+import argparse
+
+def deploy_planner_agent(project_id: str, region: str):
+    """Deploys the Planner Agent."""
+    print("Deploying Planner Agent...")
+    try:
+        subprocess.run(
+            ["python", "agents/planner/deploy.py", "--project_id", project_id, "--region", region],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print("Planner Agent deployed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error deploying Planner Agent: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
+
+def deploy_social_agent(project_id: str, region: str):
+    """Deploys the Social Agent."""
+    print("Deploying Social Agent...")
+    try:
+        subprocess.run(
+            ["python", "agents/social/deploy.py", "--project_id", project_id, "--region", region],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print("Social Agent deployed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error deploying Social Agent: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
+
+def deploy_orchestrate_agent(project_id: str, region: str):
+    """Deploys the Orchestrate Agent."""
+    print("Deploying Orchestrate Agent...")
+    try:
+        subprocess.run(
+            ["python", "agents/orchestrate/deploy.py", "--project_id", project_id, "--region", region],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print("Orchestrate Agent deployed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error deploying Orchestrate Agent: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
+
+def deploy_instavibe_app(project_id: str, region: str, image_name: str = "instavibe-app"):
+    """Builds and deploys the Instavibe App to Cloud Run."""
+    print("Deploying Instavibe App...")
+    try:
+        # Build Docker image
+        subprocess.run(
+            ["docker", "build", "-t", f"gcr.io/{project_id}/{image_name}", "instavibe/"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"Instavibe App Docker image gcr.io/{project_id}/{image_name} built successfully.")
+
+        # Push Docker image to GCR
+        subprocess.run(
+            ["docker", "push", f"gcr.io/{project_id}/{image_name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"Instavibe App Docker image gcr.io/{project_id}/{image_name} pushed successfully.")
+
+        # Deploy to Cloud Run
+        subprocess.run(
+            [
+                "gcloud",
+                "run",
+                "deploy",
+                image_name,
+                "--image",
+                f"gcr.io/{project_id}/{image_name}",
+                "--platform",
+                "managed",
+                "--region",
+                region,
+                "--project",
+                project_id,
+                "--allow-unauthenticated", # Assuming public access for now
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"Instavibe App {image_name} deployed successfully to Cloud Run in {region}.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error deploying Instavibe App: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
+
+def deploy_platform_mcp_client(project_id: str, region: str, image_name: str = "platform-mcp-client"):
+    """Builds and deploys the Platform MCP Client to Cloud Run."""
+    print("Deploying Platform MCP Client...")
+    try:
+        # Build Docker image
+        subprocess.run(
+            ["docker", "build", "-t", f"gcr.io/{project_id}/{image_name}", "agents/platform_mcp_client/"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"Platform MCP Client Docker image gcr.io/{project_id}/{image_name} built successfully.")
+
+        # Push Docker image to GCR
+        subprocess.run(
+            ["docker", "push", f"gcr.io/{project_id}/{image_name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"Platform MCP Client Docker image gcr.io/{project_id}/{image_name} pushed successfully.")
+
+        # Deploy to Cloud Run
+        subprocess.run(
+            [
+                "gcloud",
+                "run",
+                "deploy",
+                image_name,
+                "--image",
+                f"gcr.io/{project_id}/{image_name}",
+                "--platform",
+                "managed",
+                "--region",
+                region,
+                "--project",
+                project_id,
+                 "--allow-unauthenticated", # Assuming public access for now
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"Platform MCP Client {image_name} deployed successfully to Cloud Run in {region}.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error deploying Platform MCP Client: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
+
+def deploy_mcp_tool_server(project_id: str, region: str, image_name: str = "mcp-tool-server"):
+    """Builds and deploys the MCP Tool Server to Cloud Run."""
+    print("Deploying MCP Tool Server...")
+    try:
+        # Build Docker image
+        subprocess.run(
+            ["docker", "build", "-t", f"gcr.io/{project_id}/{image_name}", "tools/instavibe/"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"MCP Tool Server Docker image gcr.io/{project_id}/{image_name} built successfully.")
+
+        # Push Docker image to GCR
+        subprocess.run(
+            ["docker", "push", f"gcr.io/{project_id}/{image_name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"MCP Tool Server Docker image gcr.io/{project_id}/{image_name} pushed successfully.")
+
+        # Deploy to Cloud Run
+        subprocess.run(
+            [
+                "gcloud",
+                "run",
+                "deploy",
+                image_name,
+                "--image",
+                f"gcr.io/{project_id}/{image_name}",
+                "--platform",
+                "managed",
+                "--region",
+                region,
+                "--project",
+                project_id,
+                "--allow-unauthenticated", # Assuming public access for now
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"MCP Tool Server {image_name} deployed successfully to Cloud Run in {region}.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error deploying MCP Tool Server: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
+
+def main():
+    """
+    Main function to deploy all components of the instavibe app.
+    """
+    parser = argparse.ArgumentParser(description="Deploy all components of the instavibe app.")
+    parser.add_argument("--project_id", required=True, help="Google Cloud project ID.")
+    parser.add_argument("--region", required=True, help="Google Cloud region for deployment.")
+    parser.add_argument(
+        "--skip_agents", action="store_true", help="Skip deploying the agents."
+    )
+    parser.add_argument(
+        "--skip_app", action="store_true", help="Skip deploying the Instavibe app."
+    )
+    parser.add_argument(
+        "--skip_platform_mcp_client", action="store_true", help="Skip deploying the Platform MCP Client."
+    )
+    parser.add_argument(
+        "--skip_mcp_tool_server", action="store_true", help="Skip deploying the MCP Tool Server."
+    )
+
+    args = parser.parse_args()
+
+    if not args.skip_agents:
+        deploy_planner_agent(args.project_id, args.region)
+        deploy_social_agent(args.project_id, args.region)
+        deploy_orchestrate_agent(args.project_id, args.region)
+    else:
+        print("Skipping agent deployments.")
+
+    if not args.skip_app:
+        deploy_instavibe_app(args.project_id, args.region)
+    else:
+        print("Skipping Instavibe app deployment.")
+
+    if not args.skip_platform_mcp_client:
+        deploy_platform_mcp_client(args.project_id, args.region)
+    else:
+        print("Skipping Platform MCP Client deployment.")
+
+    if not args.skip_mcp_tool_server:
+        deploy_mcp_tool_server(args.project_id, args.region)
+    else:
+        print("Skipping MCP Tool Server deployment.")
+
+    print("All selected components deployed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a new Python script `deploy_all.py` that automates the deployment of all components of the instavibe application.

The script provides functions to:
- Deploy the Planner, Social, and Orchestrate agents using their existing `deploy.py` scripts.
- Build and deploy the Instavibe app, Platform MCP Client, and MCP Tool Server as Docker containers to Google Cloud Run.

Command-line arguments are available to specify the Google Cloud project ID, region, and to selectively skip the deployment of certain components.

The `README.md` file has been significantly updated to include:
- Detailed instructions on how to use the `deploy_all.py` script, including prerequisites and usage examples.
- Comprehensive manual deployment steps for each individual component for users like you who prefer a step-by-step approach.