### PR TITLE
Integrate Google Cloud Build into deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains the necessary scripts and configurations to deploy the 
 ## Central Deployment Script (`deploy_all.py`)
 
 A central Python script `deploy_all.py` is provided in the root directory to orchestrate the deployment of all components.
+For containerized services (Instavibe App, Platform MCP Client, MCP Tool Server), the script utilizes **Google Cloud Build** to build the container images, which are then deployed to Google Cloud Run.
 
 ### Prerequisites
 
@@ -12,10 +13,12 @@ Before running the central deployment script, ensure you have the following:
 
 1.  **Google Cloud SDK (`gcloud`)**: Installed and authenticated. You can find installation instructions [here](https://cloud.google.com/sdk/docs/install).
     *   Ensure you have logged in (`gcloud auth login`) and set your project (`gcloud config set project [YOUR_PROJECT_ID]`).
+    *   The Cloud Build API must be enabled in your GCP project. You can enable it by visiting the Google Cloud Console or by running `gcloud services enable cloudbuild.googleapis.com`.
 2.  **Python 3**: Installed on your system.
-3.  **Docker**: Installed and running on your system, if you are deploying the Dockerized services. The script will use `docker` commands to build and push images. (Alternatively, Google Cloud Build can be used as described in the manual section, which doesn't require local Docker for the build step).
-4.  **Project ID**: Your Google Cloud Project ID.
-5.  **Region**: The Google Cloud region where you want to deploy the services (e.g., `us-central1`).
+3.  **Project ID**: Your Google Cloud Project ID.
+4.  **Region**: The Google Cloud region where you want to deploy the services (e.g., `us-central1`).
+
+*Note on Docker: While Docker was previously required for local image builds, `deploy_all.py` now uses Google Cloud Build, which builds your images in the cloud. Therefore, a local Docker installation is generally not required to run the script. However, Docker might still be useful for local development and testing.*
 
 ### Usage
 
@@ -67,17 +70,18 @@ These agents are designed for deployment to Google Cloud Vertex AI Agent Engine.
 
 ### Dockerized Services (Instavibe App, Platform MCP Client, MCP Tool Server)
 
-These services are deployed as Docker containers to Google Cloud Run.
+These services are deployed as Docker containers to Google Cloud Run using Google Cloud Build.
 
 **General Steps:**
 
 For each service:
 
-1.  **Build the Docker image using Google Cloud Build:**
+1.  **Build and push the Docker image using Google Cloud Build:**
+    Navigate to the service's directory (e.g., `cd instavibe/`) and run:
     ```bash
-    gcloud builds submit --tag gcr.io/[PROJECT_ID]/[SERVICE_NAME] [SERVICE_DIRECTORY]
+    gcloud builds submit --tag gcr.io/[PROJECT_ID]/[SERVICE_NAME] . --project [PROJECT_ID]
     ```
-    Replace `[PROJECT_ID]` with your Google Cloud Project ID, `[SERVICE_NAME]` with the specific service name (e.g., `instavibe-app`), and `[SERVICE_DIRECTORY]` with the path to the directory containing the Dockerfile.
+    Replace `[PROJECT_ID]` with your Google Cloud Project ID and `[SERVICE_NAME]` with the specific service name (e.g., `instavibe-app`). The `.` indicates that the build context (including the Dockerfile) is the current directory.
 
 2.  **Deploy the image to Cloud Run:**
     ```bash
@@ -94,17 +98,17 @@ For each service:
 
 1.  **Instavibe App:**
     *   Service Name: `instavibe-app` (or your preferred name)
-    *   Service Directory (contains Dockerfile): `instavibe/`
+    *   Directory for `gcloud builds submit`: `instavibe/`
     *   Dockerfile Location: `instavibe/Dockerfile`
 
 2.  **Platform MCP Client:**
     *   Service Name: `platform-mcp-client` (or your preferred name)
-    *   Service Directory (contains Dockerfile): `agents/platform_mcp_client/`
+    *   Directory for `gcloud builds submit`: `agents/platform_mcp_client/`
     *   Dockerfile Location: `agents/platform_mcp_client/Dockerfile`
 
 3.  **MCP Tool Server:**
     *   Service Name: `mcp-tool-server` (or your preferred name)
-    *   Service Directory (contains Dockerfile): `tools/instavibe/`
+    *   Directory for `gcloud builds submit`: `tools/instavibe/`
     *   Dockerfile Location: `tools/instavibe/Dockerfile`
 
 ## Original Agent Deployment Note

--- a/deploy_all.py
+++ b/deploy_all.py
@@ -56,25 +56,28 @@ def deploy_instavibe_app(project_id: str, region: str, image_name: str = "instav
     """Builds and deploys the Instavibe App to Cloud Run."""
     print("Deploying Instavibe App...")
     try:
-        # Build Docker image
+        # Build Docker image using Google Cloud Build
+        print(f"Building Instavibe App Docker image gcr.io/{project_id}/{image_name} using Google Cloud Build...")
         subprocess.run(
-            ["docker", "build", "-t", f"gcr.io/{project_id}/{image_name}", "instavibe/"],
+            [
+                "gcloud",
+                "builds",
+                "submit",
+                "--tag",
+                f"gcr.io/{project_id}/{image_name}",
+                ".",
+                "--project",
+                project_id,
+            ],
             check=True,
             capture_output=True,
             text=True,
+            cwd="instavibe/", # Run this command in the instavibe/ directory
         )
-        print(f"Instavibe App Docker image gcr.io/{project_id}/{image_name} built successfully.")
-
-        # Push Docker image to GCR
-        subprocess.run(
-            ["docker", "push", f"gcr.io/{project_id}/{image_name}"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        print(f"Instavibe App Docker image gcr.io/{project_id}/{image_name} pushed successfully.")
+        print(f"Instavibe App Docker image gcr.io/{project_id}/{image_name} built and pushed successfully via Cloud Build.")
 
         # Deploy to Cloud Run
+        print(f"Deploying Instavibe App {image_name} to Cloud Run in {region}...")
         subprocess.run(
             [
                 "gcloud",
@@ -106,25 +109,28 @@ def deploy_platform_mcp_client(project_id: str, region: str, image_name: str = "
     """Builds and deploys the Platform MCP Client to Cloud Run."""
     print("Deploying Platform MCP Client...")
     try:
-        # Build Docker image
+        # Build Docker image using Google Cloud Build
+        print(f"Building Platform MCP Client Docker image gcr.io/{project_id}/{image_name} using Google Cloud Build...")
         subprocess.run(
-            ["docker", "build", "-t", f"gcr.io/{project_id}/{image_name}", "agents/platform_mcp_client/"],
+            [
+                "gcloud",
+                "builds",
+                "submit",
+                "--tag",
+                f"gcr.io/{project_id}/{image_name}",
+                ".",
+                "--project",
+                project_id,
+            ],
             check=True,
             capture_output=True,
             text=True,
+            cwd="agents/platform_mcp_client/", # Run this command in the agents/platform_mcp_client/ directory
         )
-        print(f"Platform MCP Client Docker image gcr.io/{project_id}/{image_name} built successfully.")
-
-        # Push Docker image to GCR
-        subprocess.run(
-            ["docker", "push", f"gcr.io/{project_id}/{image_name}"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        print(f"Platform MCP Client Docker image gcr.io/{project_id}/{image_name} pushed successfully.")
+        print(f"Platform MCP Client Docker image gcr.io/{project_id}/{image_name} built and pushed successfully via Cloud Build.")
 
         # Deploy to Cloud Run
+        print(f"Deploying Platform MCP Client {image_name} to Cloud Run in {region}...")
         subprocess.run(
             [
                 "gcloud",
@@ -156,25 +162,28 @@ def deploy_mcp_tool_server(project_id: str, region: str, image_name: str = "mcp-
     """Builds and deploys the MCP Tool Server to Cloud Run."""
     print("Deploying MCP Tool Server...")
     try:
-        # Build Docker image
+        # Build Docker image using Google Cloud Build
+        print(f"Building MCP Tool Server Docker image gcr.io/{project_id}/{image_name} using Google Cloud Build...")
         subprocess.run(
-            ["docker", "build", "-t", f"gcr.io/{project_id}/{image_name}", "tools/instavibe/"],
+            [
+                "gcloud",
+                "builds",
+                "submit",
+                "--tag",
+                f"gcr.io/{project_id}/{image_name}",
+                ".",
+                "--project",
+                project_id,
+            ],
             check=True,
             capture_output=True,
             text=True,
+            cwd="tools/instavibe/", # Run this command in the tools/instavibe/ directory
         )
-        print(f"MCP Tool Server Docker image gcr.io/{project_id}/{image_name} built successfully.")
-
-        # Push Docker image to GCR
-        subprocess.run(
-            ["docker", "push", f"gcr.io/{project_id}/{image_name}"],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        print(f"MCP Tool Server Docker image gcr.io/{project_id}/{image_name} pushed successfully.")
+        print(f"MCP Tool Server Docker image gcr.io/{project_id}/{image_name} built and pushed successfully via Cloud Build.")
 
         # Deploy to Cloud Run
+        print(f"Deploying MCP Tool Server {image_name} to Cloud Run in {region}...")
         subprocess.run(
             [
                 "gcloud",


### PR DESCRIPTION
This commit updates `deploy_all.py` to use Google Cloud Build for building Docker images for the Instavibe app, Platform MCP Client, and MCP Tool Server.

Key changes:
- The `deploy_all.py` script now uses `gcloud builds submit --tag` to build and push container images to Google Container Registry, replacing previous local Docker build commands.
- The `README.md` file has been updated to reflect these changes in both the automated script instructions and manual deployment steps.
- Prerequisites in `README.md` now state that local Docker is not strictly required for the script, but the Cloud Build API must be enabled.

This change streamlines the deployment process by leveraging Google Cloud's managed build service.