### PR TITLE
Fix: Ensure dependencies are installed before agent deployment

### DIFF
--- a/deploy_all.py
+++ b/deploy_all.py
@@ -5,6 +5,14 @@ def deploy_planner_agent(project_id: str, region: str):
     """Deploys the Planner Agent."""
     print("Deploying Planner Agent...")
     try:
+        print("Installing Planner Agent dependencies...")
+        subprocess.run(
+            ["python", "-m", "pip", "install", "-r", "requirements.txt"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd="agents/planner",
+        )
         subprocess.run(
             ["python", "deploy.py", "--project_id", project_id, "--region", region],
             check=True,
@@ -23,6 +31,14 @@ def deploy_social_agent(project_id: str, region: str):
     """Deploys the Social Agent."""
     print("Deploying Social Agent...")
     try:
+        print("Installing Social Agent dependencies...")
+        subprocess.run(
+            ["python", "-m", "pip", "install", "-r", "requirements.txt"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd="agents/social",
+        )
         subprocess.run(
             ["python", "deploy.py", "--project_id", project_id, "--region", region],
             check=True,
@@ -41,6 +57,14 @@ def deploy_orchestrate_agent(project_id: str, region: str):
     """Deploys the Orchestrate Agent."""
     print("Deploying Orchestrate Agent...")
     try:
+        print("Installing Orchestrate Agent dependencies...")
+        subprocess.run(
+            ["python", "-m", "pip", "install", "-r", "requirements.txt"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd="agents/orchestrate",
+        )
         subprocess.run(
             ["python", "deploy.py", "--project_id", project_id, "--region", region],
             check=True,
@@ -112,6 +136,14 @@ def deploy_platform_mcp_client(project_id: str, region: str):
     """Deploys the Platform MCP Client Agent to Vertex AI Agent Engine."""
     print("Deploying Platform MCP Client Agent to Vertex AI Agent Engine...")
     try:
+        print("Installing Platform MCP Client Agent dependencies...")
+        subprocess.run(
+            ["python", "-m", "pip", "install", "-r", "requirements.txt"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd="agents/platform_mcp_client",
+        )
         subprocess.run(
             [
                 "python",
@@ -207,6 +239,21 @@ def main():
     )
 
     args = parser.parse_args()
+
+    print("Installing root dependencies...")
+    try:
+        subprocess.run(
+            ["python", "-m", "pip", "install", "-r", "requirements.txt"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print("Root dependencies installed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error installing root dependencies: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        raise
 
     if not args.skip_agents:
         deploy_planner_agent(args.project_id, args.region)


### PR DESCRIPTION
The 'deploy_all.py' script was attempting to deploy agents without first ensuring their specific Python dependencies were installed. This led to a 'ModuleNotFoundError' when an agent's deploy script (e.g., 'agents/planner/deploy.py') was executed, as it couldn't find modules like 'google.adk'.

This commit modifies 'deploy_all.py' to:
1. Install dependencies from the root 'requirements.txt' at the beginning of the main execution.
2. For each agent (planner, social, orchestrate, platform_mcp_client), install its specific requirements from its 'requirements.txt' file (e.g., 'agents/planner/requirements.txt') before attempting to run its deployment script.

This ensures that the necessary environment and packages are set up correctly, resolving the 'ModuleNotFoundError' and making the deployment process more robust.