### PR TITLE
Fix: Correct relative paths for local wheel file in agent requirements

### DIFF
--- a/agents/planner/requirements.txt
+++ b/agents/planner/requirements.txt
@@ -1,5 +1,5 @@
 google-cloud-aiplatform[adk,agent_engines]>=1.90.0
 google-adk==0.4.0
 python-dateutil==2.9.0.post0
-a2a_common-0.1.0-py3-none-any.whl
+../a2a_common-0.1.0-py3-none-any.whl
 deprecated==1.2.18

--- a/agents/platform_mcp_client/requirements.txt
+++ b/agents/platform_mcp_client/requirements.txt
@@ -6,5 +6,5 @@ python-dateutil==2.9.0.post0
 humanize==4.12.3
 nest_asyncio==1.6.0
 asyncclick==8.1.8.0
-a2a_common-0.1.0-py3-none-any.whl
+../a2a_common-0.1.0-py3-none-any.whl
 deprecated==1.2.18

--- a/agents/social/requirements.txt
+++ b/agents/social/requirements.txt
@@ -4,5 +4,5 @@ google-adk==0.4.0
 python-dotenv==1.1.0
 fastapi==0.115.12
 urllib3==2.4.0
-a2a_common-0.1.0-py3-none-any.whl
+../a2a_common-0.1.0-py3-none-any.whl
 deprecated==1.2.18


### PR DESCRIPTION
The previous change to install agent-specific dependencies using their respective 'requirements.txt' files (by changing the current working directory to the agent's folder) revealed an issue with how the local 'a2a_common-0.1.0-py3-none-any.whl' was referenced.

The paths in 'agents/planner/requirements.txt',
'agents/social/requirements.txt', and
'agents/platform_mcp_client/requirements.txt' were 'a2a_common-0.1.0-py3-none-any.whl'. When 'pip install' is run from within these subdirectories (e.g., 'agents/planner/'), this path is incorrect as the wheel file is located at
'agents/a2a_common-0.1.0-py3-none-any.whl'.

This commit updates these 'requirements.txt' files to use the correct relative path '../a2a_common-0.1.0-py3-none-any.whl', ensuring pip can find the local dependency when installing requirements from within each agent's directory.

The location of the wheel file has been verified to be 'agents/a2a_common-0.1.0-py3-none-any.whl'.