### PR TITLE
Fix: Set PYTHONPATH for agent deployment scripts

### DIFF
--- a/deploy_all.py
+++ b/deploy_all.py
@@ -14,7 +14,7 @@ def deploy_planner_agent(project_id: str, region: str):
             cwd="agents/planner",
         )
         subprocess.run(
-            ["python", "deploy.py", "--project_id", project_id, "--region", region],
+            ["env", "PYTHONPATH=../..", "python", "deploy.py", "--project_id", project_id, "--region", region],
             check=True,
             capture_output=True,
             text=True,
@@ -40,7 +40,7 @@ def deploy_social_agent(project_id: str, region: str):
             cwd="agents/social",
         )
         subprocess.run(
-            ["python", "deploy.py", "--project_id", project_id, "--region", region],
+            ["env", "PYTHONPATH=../..", "python", "deploy.py", "--project_id", project_id, "--region", region],
             check=True,
             capture_output=True,
             text=True,
@@ -66,7 +66,7 @@ def deploy_orchestrate_agent(project_id: str, region: str):
             cwd="agents/orchestrate",
         )
         subprocess.run(
-            ["python", "deploy.py", "--project_id", project_id, "--region", region],
+            ["env", "PYTHONPATH=../..", "python", "deploy.py", "--project_id", project_id, "--region", region],
             check=True,
             capture_output=True,
             text=True,
@@ -146,6 +146,8 @@ def deploy_platform_mcp_client(project_id: str, region: str):
         )
         subprocess.run(
             [
+                "env",
+                "PYTHONPATH=../..",
                 "python",
                 "deploy.py", # Now relative to cwd
                 "--project_id",


### PR DESCRIPTION
The agent-specific 'deploy.py' scripts (e.g., 'agents/planner/deploy.py') were failing with 'ModuleNotFoundError: No module named "agents"' because they were executed from within their respective subdirectories (e.g., 'cwd="agents/planner"'), and the project root directory (which contains the top-level 'agents' package) was not in Python's import search path.

This commit modifies 'deploy_all.py' to prepend 'PYTHONPATH=../..' to the execution command for each agent's 'deploy.py' script. Since these scripts are located two levels down from the project root (e.g., 'agents/planner/deploy.py'), setting 'PYTHONPATH=../..' when the 'cwd' is 'agents/planner/' (or similar) correctly adds the project root to 'sys.path'.

This allows the agent deployment scripts to successfully import modules using absolute paths from the project root, such as 'from agents.planner import agent'.