### PR TITLE
Hi there! I've updated the deployment script for you.

### DIFF
--- a/agents/planner/deploy.py
+++ b/agents/planner/deploy.py
@@ -70,10 +70,16 @@ deployed_agent = agent_engines.create(
 # Overwrite with the refined version:
 from agents.planner import agent as planner_adk_agent_module
 from agents.planner.planner_agent import PlannerAgent
-from vertexai import agent_engines
-from vertexai.preview.reasoning_engines import AdkApp
+from vertexai import ReasoningEngine as VertexAIReasoningEngine
+from google.cloud.aiplatform_v1.types import ReasoningEngine as ReasoningEngineGAPIC
+from google.cloud.aiplatform_v1.types import ReasoningEngineSpec
+from google.cloud.aiplatform_v1.types import ReasoningEngineSpecPackageSpec
+# from google.cloud.aiplatform_v1.types import ReasoningEngineSpecDeploymentSpec # Optional, if not used
+# from google.cloud.aiplatform_v1.types import MachineSpec # Optional, if not used
+import os
+from vertexai.preview.reasoning_engines import AdkApp # Keep AdkApp if used for local testing
 
-# Instantiate the ReasoningEngine wrapper
+# Instantiate the ReasoningEngine wrapper (if still needed for AdkApp)
 planner_reasoning_engine_instance = PlannerAgent()
 
 # Define display_name and description for the agent
@@ -81,23 +87,59 @@ display_name = "Planner Agent"
 description = """This agent helps users plan activities and events, considering their interests, budget, and location. It can generate creative and fun plan suggestions."""
 
 # Create the AdkApp instance for local execution (using the ReasoningEngine)
+# This part can remain if AdkApp is used for local testing/serving
 app = AdkApp(
     agent=planner_reasoning_engine_instance,
     enable_tracing=True,
 )
 
-# Create the deployed agent for Vertex AI Agent Engines (using the ADK agent module)
-# The 'app' parameter here refers to the ADK agent or module to be deployed.
-# The 'requirements_path' should be relative to this deploy.py file if it's co-located
-# with requirements.txt, or a full path from the execution root.
-# Given the subtask states "Verify agents/planner/requirements.txt exists",
-# the path should be "./requirements.txt" if deploy.py is in agents/planner/
-# or "agents/planner/requirements.txt" if deploy.py is at the root.
-# The orchestrate example uses "./requirements.txt", implying it's co-located.
-# Let's assume this deploy.py will be in agents/planner/
-deployed_agent = agent_engines.create(
-    app=planner_adk_agent_module,
+# Read requirements.txt
+requirements_list = []
+# This script is run with cwd="agents/planner" by deploy_all.py
+requirements_file_path = "./requirements.txt"
+if os.path.exists(requirements_file_path):
+    with open(requirements_file_path, "r") as f:
+        requirements_list = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+else:
+    print(f"Warning: Requirements file not found at {requirements_file_path}. Proceeding with empty requirements for deployment.")
+
+# New deployment logic using ReasoningEngine
+reasoning_engine_package_spec = ReasoningEngineSpecPackageSpec(
+    python_module_name="agents.planner.agent", # planner_adk_agent_module is agents.planner.agent
+    requirements=requirements_list
+)
+
+reasoning_engine_spec = ReasoningEngineSpec(
+    package_spec=reasoning_engine_package_spec
+    # Example of adding deployment_spec if needed in the future:
+    # deployment_spec=ReasoningEngineSpecDeploymentSpec(
+    #     machine_spec=MachineSpec(machine_type="n1-standard-2"),
+    # )
+)
+
+gapic_reasoning_engine_config = ReasoningEngineGAPIC(
     display_name=display_name,
     description=description,
-    requirements_path="./requirements.txt", # Assuming requirements.txt is in the same directory
+    spec=reasoning_engine_spec
 )
+
+print("Deploying Planner Agent as Reasoning Engine...")
+# The high-level SDK's .create() method typically infers project and location
+# if aiplatform.init() was called. Ensure aiplatform.init() is called somewhere before this,
+# or pass project and location explicitly if the SDK requires it and they are not inferred.
+# For this change, we assume project and location are handled (e.g., by `gcloud auth application-default login` and `gcloud config set project`)
+# or aiplatform.init() is called in a higher-level script like deploy_all.py or by the environment.
+deployed_agent_resource = VertexAIReasoningEngine.create(reasoning_engine=gapic_reasoning_engine_config)
+
+print(f"Planner Agent (Reasoning Engine) deployed successfully: {deployed_agent_resource.name}")
+# Constructing the console link (ensure location and project are correctly inferred or passed)
+# project_id = deployed_agent_resource.project # or client.project if available
+# location = deployed_agent_resource.location # or client.location
+# print(f"View in console: https://console.cloud.google.com/vertex-ai/reasoning-engines/locations/{location}/reasoning-engines/{deployed_agent_resource.resource_id}?project={project_id}")
+# For now, let's print the available info:
+print(f"Deployed Reasoning Engine Name: {deployed_agent_resource.name}")
+print(f"Resource ID: {deployed_agent_resource.resource_id}")
+
+# Ensure any downstream code that used 'deployed_agent' now uses 'deployed_agent_resource'.
+# For example, if the script was returning 'deployed_agent', it should now return 'deployed_agent_resource'.
+# The original script didn't explicitly return it, but this is a good practice reminder.


### PR DESCRIPTION
The script in 'agents/planner/deploy.py' wasn't working correctly because of an SDK update.

Here’s what I did to update the deployment logic in 'agents/planner/deploy.py':
1. I imported `vertexai.ReasoningEngine` and the necessary GAPIC types.
2. I made sure the script reads the agent's Python dependencies from './requirements.txt'.
3. I constructed a `ReasoningEngineGAPIC` object and populated its `spec` with a `ReasoningEngineSpec`.
4. I configured the `ReasoningEngineSpec`'s `package_spec` with the Python module name and the list of dependencies.
5. Finally, I updated the script to call `VertexAIReasoningEngine.create()` with the configured `ReasoningEngineGAPIC` object to deploy the agent.

This brings the deployment script in line with the current version of the Vertex AI SDK.