### PR TITLE
Fix: Update google-cloud-aiplatform version

### DIFF
--- a/agents/planner/requirements.txt
+++ b/agents/planner/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-aiplatform[adk,agent_engines]>=1.90.0
+google-cloud-aiplatform[adk,agent_engines]==1.95.1
 google-adk==0.4.0
 python-dateutil==2.9.0.post0
 ../a2a_common-0.1.0-py3-none-any.whl


### PR DESCRIPTION
I encountered an ImportError:
`cannot import name 'ReasoningEngineSpecPackageSpec' from 'google.cloud.aiplatform_v1.types'`.

This was caused by an outdated version of the `google-cloud-aiplatform` library. This commit updates the version in `agents/planner/requirements.txt` to `1.95.1` to ensure the necessary class is available.