### PR TITLE
I've made a fix to align the `google-cloud-aiplatform` and `google-ad…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
-google-cloud-aiplatform[adk,agent_engines]==1.91.0
+google-cloud-aiplatform[adk,agent_engines]==1.95.1
 Flask==3.1.0
 mcp[cli]==1.7.1
-google-adk==0.4.0
+google-adk==1.0.0
 google-cloud-spanner==3.54.0
 python-dateutil==2.9.0.post0
 humanize==4.12.3
 nest_asyncio==1.6.0
 asyncclick==8.1.8.0
-google-adk[eval]==0.4.0
+google-adk[eval]==1.0.0
 build==1.2.2.post1
 google-genai==1.14.0
 ./agents/a2a_common-0.1.0-py3-none-any.whl


### PR DESCRIPTION
…k` versions.

This should resolve an `ImportError` for `ReasoningEngineSpecPackageSpec`.

The issue was caused by a version conflict:
- Your root `requirements.txt` had `google-cloud-aiplatform==1.91.0` and `google-adk==0.4.0`.
- Your `agents/planner/requirements.txt` had `google-cloud-aiplatform==1.95.1` (correctly) and `google-adk==1.0.0` (correctly).

The `PYTHONPATH=../..` setting in `deploy_all.py` likely caused the older root version of `google-cloud-aiplatform` (1.91.0) to be loaded, which lacks `ReasoningEngineSpecPackageSpec`.

I've aligned the versions in your root `requirements.txt`:
- I updated `google-cloud-aiplatform` to `1.95.1`.
- I updated `google-adk` and `google-adk[eval]` to `1.0.0`.

This ensures consistency and that the correct, newer versions of the libraries are used, resolving both the `ImportError` and potential pip dependency conflicts.