### PR TITLE
Okay, I've refactored the agent deployment scripts to use the GAPIC c…

### DIFF
--- a/agents/orchestrate/deploy.py
+++ b/agents/orchestrate/deploy.py
@@ -1,70 +1,231 @@
 import os
+import uuid
+from urllib.parse import urlparse
+import cloudpickle
+import tarfile
+import tempfile
+import shutil
+
+from google.cloud import aiplatform as vertexai # Standard alias
+from google.cloud.aiplatform_v1.services import reasoning_engine_service
+from google.cloud.aiplatform_v1.types import ReasoningEngine as ReasoningEngineGAPIC
+from google.cloud.aiplatform_v1.types import ReasoningEngineSpec
+from google.cloud import storage
+import google.auth
+
 from agents.orchestrate import agent as orchestrate_adk_agent_module
-from vertexai import agent_engines
-from vertexai.preview.reasoning_engines import AdkApp # For local execution
+
 
 def deploy_orchestrate_main_func(project_id: str, region: str, base_dir: str):
     """
-    Deploys the Orchestrate Agent to Vertex AI Agent Engines.
+    Deploys the Orchestrate Agent to Vertex AI Reasoning Engines using GAPIC client.
 
     Args:
         project_id: The Google Cloud project ID.
         region: The Google Cloud region for deployment.
         base_dir: The base directory of the repository.
     """
-    # aiplatform.init() is expected to be called by the main deployment script (deploy_all.py)
-
     display_name = "Orchestrate Agent"
     description = """
   This is the agent responsible for choosing which remote agents to send
   tasks to and coordinate their work on helping user to get social 
 """
 
-    requirements_file_path = os.path.join(base_dir, "agents/orchestrate/requirements.txt")
-    requirements_list = []
-    if os.path.exists(requirements_file_path):
-        with open(requirements_file_path, "r") as f:
-            requirements_list = [line.strip() for line in f if line.strip() and not line.startswith('#')]
-    else:
-        # Fallback for cases where base_dir might be agents/orchestrate itself (e.g. direct execution)
-        fallback_requirements_path = "./requirements.txt"
-        if os.path.exists(fallback_requirements_path):
-            print(f"Using fallback requirements path: {fallback_requirements_path}")
-            with open(fallback_requirements_path, "r") as f:
-                requirements_list = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+    staging_bucket_uri = vertexai.initializer.global_config.staging_bucket
+    if not staging_bucket_uri:
+        raise ValueError("Vertex AI staging bucket is not set. Please configure it via aiplatform.init(staging_bucket='gs://your-bucket').")
+
+    parsed_uri = urlparse(staging_bucket_uri)
+    bucket_name = parsed_uri.netloc
+    bucket_prefix = parsed_uri.path.lstrip('/')
+    if bucket_prefix and not bucket_prefix.endswith('/'):
+        bucket_prefix += '/'
+
+    try:
+        storage_client = storage.Client(project=project_id)
+        bucket = storage_client.bucket(bucket_name)
+    except google.auth.exceptions.DefaultCredentialsError as e:
+        print(f"ERROR: Google Cloud Default Credentials not found. {e}")
+        print("Please ensure you have authenticated via `gcloud auth application-default login` "
+              "or set the GOOGLE_APPLICATION_CREDENTIALS environment variable.")
+        raise
+
+    agent_instance_to_pickle = orchestrate_adk_agent_module.root_agent
+
+    pickled_agent_filename = f"orchestrate_agent_pickle_{uuid.uuid4()}.pkl"
+    gcs_pickle_path = os.path.join(bucket_prefix, 'reasoning_engine_packages', pickled_agent_filename)
+    blob_pickle = bucket.blob(gcs_pickle_path)
+    with blob_pickle.open("wb") as f:
+        cloudpickle.dump(agent_instance_to_pickle, f)
+    pickle_object_gcs_uri = f"gs://{bucket_name}/{gcs_pickle_path}"
+    print(f"Uploaded pickled Orchestrate agent to {pickle_object_gcs_uri}")
+
+    local_wheel_filename = "a2a_common-0.1.0-py3-none-any.whl"
+
+    agents_content_base_path = base_dir
+    # Check if base_dir is 'agents/orchestrate' or similar agent-specific path
+    if os.path.basename(base_dir) == "orchestrate" and os.path.isdir(os.path.join(base_dir, "..", "agents")):
+        agents_content_base_path = os.path.abspath(os.path.join(base_dir, ".."))
+    # Check if base_dir is 'agents'
+    elif os.path.basename(base_dir) == "agents" and os.path.isdir(base_dir):
+        agents_content_base_path = os.path.abspath(os.path.join(base_dir, ".."))
+    # Default assumes base_dir is repo root, or a path from which agents/ can be found
+    elif not os.path.isdir(os.path.join(base_dir, "agents")):
+        # If 'agents' is not directly under base_dir, try one level up from base_dir assuming base_dir is like /path/to/repo/agents/orchestrate
+        potential_repo_root = os.path.abspath(os.path.join(base_dir, "..", ".."))
+        if os.path.isdir(os.path.join(potential_repo_root, "agents")):
+            agents_content_base_path = potential_repo_root
         else:
-             print(f"Warning: Requirements file not found at {requirements_file_path} or {fallback_requirements_path}. Proceeding with empty requirements for deployment.")
+            # If all else fails, stick with base_dir and hope for the best or let specific file checks fail
+            pass
 
-    print(f"Deploying Orchestrate Agent from module: {orchestrate_adk_agent_module.__name__} to project {project_id} in {region} with requirements from {requirements_file_path}...")
+    local_wheel_path = os.path.join(agents_content_base_path, "agents", local_wheel_filename)
+    if not os.path.exists(local_wheel_path):
+        raise FileNotFoundError(f"Local wheel {local_wheel_path} not found. Base dir: {base_dir}, Derived agents_content_base_path: {agents_content_base_path}")
 
-    deployed_agent = agent_engines.create(
-        app=orchestrate_adk_agent_module,
+    actual_orchestrate_src_path = os.path.join(agents_content_base_path, "agents", "orchestrate")
+    if not os.path.isdir(actual_orchestrate_src_path):
+        raise FileNotFoundError(f"Source directory {actual_orchestrate_src_path} not found.")
+
+    actual_app_src_path = os.path.join(agents_content_base_path, "agents", "app")
+    if not os.path.isdir(actual_app_src_path):
+        raise FileNotFoundError(f"Local dependency directory {actual_app_src_path} not found.")
+
+    dependency_files_gcs_uri = None
+    with tempfile.TemporaryDirectory() as temp_dir_for_tar:
+        temp_agents_root_in_tar_dir = os.path.join(temp_dir_for_tar, "agents")
+        os.makedirs(temp_agents_root_in_tar_dir, exist_ok=True)
+
+        copied_wheel_path = os.path.join(temp_dir_for_tar, local_wheel_filename)
+        shutil.copy(local_wheel_path, copied_wheel_path)
+        print(f"Copied wheel to {copied_wheel_path}")
+
+        dest_orchestrate_in_temp_agents = os.path.join(temp_agents_root_in_tar_dir, "orchestrate")
+        shutil.copytree(actual_orchestrate_src_path, dest_orchestrate_in_temp_agents, dirs_exist_ok=True)
+        print(f"Copied {actual_orchestrate_src_path} to {dest_orchestrate_in_temp_agents}")
+
+        dest_app_in_temp_agents = os.path.join(temp_agents_root_in_tar_dir, "app")
+        shutil.copytree(actual_app_src_path, dest_app_in_temp_agents, dirs_exist_ok=True)
+        print(f"Copied {actual_app_src_path} to {dest_app_in_temp_agents}")
+
+        staged_agents_init_py = os.path.join(temp_agents_root_in_tar_dir, "__init__.py")
+        source_agents_init_py = os.path.join(agents_content_base_path, "agents", "__init__.py")
+        if os.path.exists(source_agents_init_py):
+            shutil.copy(source_agents_init_py, staged_agents_init_py)
+            print(f"Copied existing agents/__init__.py to {staged_agents_init_py}")
+        elif not os.path.exists(staged_agents_init_py):
+            with open(staged_agents_init_py, "w") as f_init:
+                f_init.write("# Auto-generated __init__.py for agents package\n")
+            print(f"Created empty {staged_agents_init_py} as it was not found in source")
+
+        tarball_local_filename = f"orchestrate_deps_{uuid.uuid4()}.tar.gz"
+        tarball_local_path = os.path.join(tempfile.gettempdir(), tarball_local_filename)
+
+        print(f"Creating tarball {tarball_local_path} containing {local_wheel_filename} (at root) and 'agents/' dir (with 'orchestrate/' and 'app/').")
+        with tarfile.open(tarball_local_path, "w:gz") as tar:
+            tar.add(copied_wheel_path, arcname=local_wheel_filename)
+            tar.add(temp_agents_root_in_tar_dir, arcname="agents")
+
+        gcs_tarball_path = os.path.join(bucket_prefix, 'reasoning_engine_dependencies', tarball_local_filename)
+        blob_tarball = bucket.blob(gcs_tarball_path)
+        blob_tarball.upload_from_filename(tarball_local_path)
+        dependency_files_gcs_uri = f"gs://{bucket_name}/{gcs_tarball_path}"
+        print(f"Uploaded dependency tarball to {dependency_files_gcs_uri}")
+        os.remove(tarball_local_path)
+
+    original_requirements_file_path = os.path.join(agents_content_base_path, "agents", "orchestrate", "requirements.txt")
+    if not os.path.exists(original_requirements_file_path):
+        if os.path.basename(base_dir) == "orchestrate" and os.path.exists(os.path.join(base_dir, "requirements.txt")): # base_dir is agents/orchestrate
+            original_requirements_file_path = os.path.join(base_dir, "requirements.txt")
+        else: # Try if base_dir is agents path
+            alt_req_path = os.path.join(base_dir, "orchestrate", "requirements.txt")
+            if os.path.basename(base_dir) == "agents" and os.path.exists(alt_req_path):
+                original_requirements_file_path = alt_req_path
+            else:
+                raise FileNotFoundError(f"Original requirements file for orchestrate not found. Checked: {original_requirements_file_path} and fallbacks based on base_dir: {base_dir}")
+
+    print(f"Reading original requirements from: {original_requirements_file_path}")
+    with open(original_requirements_file_path, "r") as f:
+        original_requirements_lines = f.readlines()
+
+    modified_requirements_lines = []
+    found_gcs_package = False
+    added_common_wheel = False
+
+    for line in original_requirements_lines:
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith('#'):
+            modified_requirements_lines.append(line)
+            continue
+        if "../app" in stripped_line:
+            print(f"Modified requirements: Removed '{stripped_line}' (app directory is now part of 'agents' package in tarball).")
+            continue
+        if "a2a_common" in stripped_line: # Covers cases like '../a2a_common...' or just 'a2a_common...'
+            if not added_common_wheel: # Add only once
+                modified_requirements_lines.append(f"{local_wheel_filename}\n")
+                print(f"Modified requirements: Replaced/Ensured '{stripped_line}' with '{local_wheel_filename}'.")
+                added_common_wheel = True
+            else:
+                print(f"Modified requirements: Removed redundant a2a_common reference '{stripped_line}'.")
+            continue
+
+        modified_requirements_lines.append(line)
+        if "google-cloud-storage" in stripped_line:
+            found_gcs_package = True
+
+    if not added_common_wheel:
+        modified_requirements_lines.append(f"{local_wheel_filename}\n")
+        print(f"Modified requirements: Added '{local_wheel_filename}'.")
+        added_common_wheel = True
+
+    if not found_gcs_package:
+        modified_requirements_lines.append("google-cloud-storage\n")
+        print("Modified requirements: Added 'google-cloud-storage'.")
+
+    modified_requirements_content = "".join(modified_requirements_lines)
+    # Ensure newlines are correctly formatted if joining lines that might not have them
+    modified_requirements_content = '\n'.join(filter(None, [l.strip() for l in modified_requirements_content.splitlines()])) + '\n'
+
+    print("---- BEGIN Modified requirements.txt content for Orchestrate ----")
+    print(modified_requirements_content)
+    print("---- END Modified requirements.txt content ----")
+
+    gcs_requirements_filename = f"orchestrate_requirements_modified_{uuid.uuid4()}.txt"
+    gcs_requirements_path = os.path.join(bucket_prefix, 'reasoning_engine_packages', gcs_requirements_filename)
+    blob_reqs = bucket.blob(gcs_requirements_path)
+    blob_reqs.upload_from_string(modified_requirements_content)
+    requirements_gcs_uri = f"gs://{bucket_name}/{gcs_requirements_path}"
+    print(f"Uploaded modified requirements to {requirements_gcs_uri}")
+
+    current_package_spec = ReasoningEngineSpec.PackageSpec(
+        pickle_object_gcs_uri=pickle_object_gcs_uri,
+        requirements_gcs_uri=requirements_gcs_uri,
+        dependency_files_gcs_uri=dependency_files_gcs_uri,
+        python_version="3.12"
+    )
+
+    reasoning_engine_spec = ReasoningEngineSpec(
+        package_spec=current_package_spec
+    )
+
+    gapic_reasoning_engine_config = ReasoningEngineGAPIC(
         display_name=display_name,
         description=description,
-        requirements=requirements_list,
-        # project and location are typically inferred from aiplatform.init()
-    )
-    print(f"Orchestrate Agent deployed successfully: {deployed_agent.name}")
-    # print(f"Deployed Reasoning Engine Name: {deployed_agent.name}") # Duplicates previous line
-    # print(f"Resource ID: {deployed_agent.resource_id}") # Assuming resource_id is available
-    return deployed_agent
-
-if __name__ == "__main__":
-    # This block is for local execution or testing of the AdkApp.
-    print("Configuring Orchestrate Agent for local AdkApp execution...")
-
-    # The root_agent is defined in orchestrate_adk_agent_module (agents/orchestrate/agent.py)
-    # Ensure aiplatform is initialized if any ADK components require project/location for local run
-    # import google.cloud.aiplatform as aiplatform
-    # aiplatform.init(project="your-local-project", location="us-central1") # Example for local run
-
-    app = AdkApp(
-        agent=orchestrate_adk_agent_module.root_agent,
-        enable_tracing=True,
+        spec=reasoning_engine_spec
     )
 
-    print("AdkApp for Orchestrate Agent is configured. To run locally, use 'adk run' or 'adk serve'.")
-    # Example for testing the cloud deployment function (requires auth, project, region):
-    # deploy_orchestrate_main_func(project_id="your-gcp-project", region="us-central1", base_dir=".")
-    # To run the AdkApp server (example):
-    # app.serve(host="0.0.0.0", port=8080)
+    print(f"Initializing GAPIC ReasoningEngineServiceClient with endpoint: {region}-aiplatform.googleapis.com")
+    client_options = {"api_endpoint": f"{region}-aiplatform.googleapis.com"}
+    gapic_client = reasoning_engine_service.ReasoningEngineServiceClient(client_options=client_options)
+    parent_path = f"projects/{project_id}/locations/{region}"
+
+    print(f"Creating Orchestrate Reasoning Engine using GAPIC client with parent: {parent_path}...")
+    operation = gapic_client.create_reasoning_engine(
+        parent=parent_path,
+        reasoning_engine=gapic_reasoning_engine_config
+    )
+    print(f"Reasoning Engine creation operation started: {operation.operation.name}")
+    print("Waiting for operation to complete...")
+    deployed_agent_resource = operation.result()
+    print(f"Orchestrate Agent (Reasoning Engine) deployed successfully via GAPIC: {deployed_agent_resource.name}")
+    return deployed_agent_resource

--- a/agents/platform_mcp_client/deploy.py
+++ b/agents/platform_mcp_client/deploy.py
@@ -1,76 +1,205 @@
-import argparse
 import os
-from google.cloud import aiplatform
-from vertexai import agent_engines
+import uuid
+from urllib.parse import urlparse
+import cloudpickle
+import tarfile
+import tempfile
+import shutil # For shutil.copy and shutil.copytree
+
+from google.cloud import aiplatform as vertexai
+from google.cloud.aiplatform_v1.services import reasoning_engine_service
+from google.cloud.aiplatform_v1.types import ReasoningEngine as ReasoningEngineGAPIC
+from google.cloud.aiplatform_v1.types import ReasoningEngineSpec
+from google.cloud import storage
+import google.auth # For google.auth.exceptions
 
 # Import the agent module that contains the `root_agent`
 from agents.platform_mcp_client import agent as platform_mcp_client_agent_module
 
 def deploy_platform_mcp_client_main_func(project_id: str, region: str, base_dir: str):
-    """Deploys the Platform MCP Client Agent to Vertex AI Agent Engine."""
-    # aiplatform.init() is expected to be called by deploy_all.py
-    # aiplatform.init(project=project_id, location=region)
+    """Deploys the Platform MCP Client Agent to Vertex AI Reasoning Engines using GAPIC client."""
 
     display_name = "Platform MCP Client Agent"
     description = "An agent that connects to an MCP Tool Server to provide tools for other agents or clients. It can interact with Instavibe services like creating posts and events."
 
-    # The ADK agent to deploy. This should be the `root_agent` instance
-    # from the platform_mcp_client_agent_module.
-    # We need to ensure `root_agent` is initialized before this script runs,
-    # or that accessing it triggers initialization if needed.
-    # The agent.py script seems to initialize it at module level.
-    adk_agent_to_deploy = platform_mcp_client_agent_module.root_agent
+    staging_bucket_uri = vertexai.initializer.global_config.staging_bucket
+    if not staging_bucket_uri:
+        raise ValueError("Vertex AI staging bucket is not set. Please configure it via aiplatform.init(staging_bucket='gs://your-bucket').")
 
-    if adk_agent_to_deploy is None:
-        print("Error: The root_agent in platform_mcp_client.agent is None. Ensure it's initialized.")
-        return
+    parsed_uri = urlparse(staging_bucket_uri)
+    bucket_name = parsed_uri.netloc
+    bucket_prefix = parsed_uri.path.lstrip('/')
+    if bucket_prefix and not bucket_prefix.endswith('/'):
+        bucket_prefix += '/'
 
-    requirements_file_path = os.path.join(base_dir, "agents/platform_mcp_client/requirements.txt")
-    requirements_list = []
-    if os.path.exists(requirements_file_path):
-        with open(requirements_file_path, "r") as f:
-            requirements_list = [line.strip() for line in f if line.strip() and not line.startswith('#')]
-    else:
-        # Fallback for direct execution
-        fallback_requirements_path = "./requirements.txt"
-        if os.path.exists(fallback_requirements_path):
-            print(f"Using fallback requirements path for platform_mcp_client: {fallback_requirements_path}")
-            with open(fallback_requirements_path, "r") as f:
-                requirements_list = [line.strip() for line in f if line.strip() and not line.startswith('#')]
-        else:
-            print(f"Warning: Requirements file not found at {requirements_file_path} or {fallback_requirements_path} for platform_mcp_client. Proceeding with empty requirements.")
+    try:
+        storage_client = storage.Client(project=project_id)
+        bucket = storage_client.bucket(bucket_name)
+    except google.auth.exceptions.DefaultCredentialsError as e:
+        print(f"ERROR: Google Cloud Default Credentials not found. {e}")
+        print("Please ensure you have authenticated via `gcloud auth application-default login` "
+              "or set the GOOGLE_APPLICATION_CREDENTIALS environment variable.")
+        raise
+
+    # The agent to pickle is platform_mcp_client_agent_module.root_agent
+    agent_instance_to_pickle = platform_mcp_client_agent_module.root_agent
+    if agent_instance_to_pickle is None:
+        raise ValueError("Error: The root_agent in platform_mcp_client.agent is None. Ensure it's initialized.")
+
+    pickled_agent_filename = f"platform_mcp_client_agent_pickle_{uuid.uuid4()}.pkl"
+    gcs_pickle_path = os.path.join(bucket_prefix, 'reasoning_engine_packages', pickled_agent_filename)
+    blob_pickle = bucket.blob(gcs_pickle_path)
+    with blob_pickle.open("wb") as f:
+        cloudpickle.dump(agent_instance_to_pickle, f)
+    pickle_object_gcs_uri = f"gs://{bucket_name}/{gcs_pickle_path}"
+    print(f"Uploaded pickled Platform MCP Client agent to {pickle_object_gcs_uri}")
+
+    local_wheel_filename = "a2a_common-0.1.0-py3-none-any.whl"
+
+    agents_content_base_path = base_dir
+    # Adjust agents_content_base_path if base_dir is specific
+    if os.path.basename(base_dir) == "platform_mcp_client" and os.path.isdir(os.path.join(base_dir, "..", "agents")):
+        agents_content_base_path = os.path.abspath(os.path.join(base_dir, ".."))
+    elif os.path.basename(base_dir) == "agents" and os.path.isdir(base_dir):
+        agents_content_base_path = os.path.abspath(os.path.join(base_dir, ".."))
+    elif not os.path.isdir(os.path.join(base_dir, "agents")):
+       potential_repo_root = os.path.abspath(os.path.join(base_dir, "..", ".."))
+       if os.path.isdir(os.path.join(potential_repo_root, "agents")):
+           agents_content_base_path = potential_repo_root
+
+    local_wheel_path = os.path.join(agents_content_base_path, "agents", local_wheel_filename)
+    if not os.path.exists(local_wheel_path):
+        raise FileNotFoundError(f"Local wheel {local_wheel_path} not found. Base dir: {base_dir}, Derived agents_content_base_path: {agents_content_base_path}")
+
+    actual_platform_mcp_client_src_path = os.path.join(agents_content_base_path, "agents", "platform_mcp_client")
+    if not os.path.isdir(actual_platform_mcp_client_src_path):
+        raise FileNotFoundError(f"Source directory {actual_platform_mcp_client_src_path} not found.")
+
+    dependency_files_gcs_uri = None
+    with tempfile.TemporaryDirectory() as temp_dir_for_tar:
+        temp_agents_root_in_tar_dir = os.path.join(temp_dir_for_tar, "agents")
+        os.makedirs(temp_agents_root_in_tar_dir, exist_ok=True)
+
+        copied_wheel_path = os.path.join(temp_dir_for_tar, local_wheel_filename)
+        shutil.copy(local_wheel_path, copied_wheel_path)
+        print(f"Copied wheel to {copied_wheel_path}")
+
+        dest_platform_mcp_client_in_temp_agents = os.path.join(temp_agents_root_in_tar_dir, "platform_mcp_client")
+        shutil.copytree(actual_platform_mcp_client_src_path, dest_platform_mcp_client_in_temp_agents, dirs_exist_ok=True)
+        print(f"Copied {actual_platform_mcp_client_src_path} to {dest_platform_mcp_client_in_temp_agents}")
+
+        staged_agents_init_py = os.path.join(temp_agents_root_in_tar_dir, "__init__.py")
+        source_agents_init_py = os.path.join(agents_content_base_path, "agents", "__init__.py")
+        if os.path.exists(source_agents_init_py):
+            shutil.copy(source_agents_init_py, staged_agents_init_py)
+        elif not os.path.exists(staged_agents_init_py): # Create if not copied and not already exists (e.g. from previous copytree)
+            with open(staged_agents_init_py, "w") as f_init:
+                f_init.write("# Auto-generated __init__.py for agents package\n")
+
+        tarball_local_filename = f"platform_mcp_client_deps_{uuid.uuid4()}.tar.gz"
+        tarball_local_path = os.path.join(tempfile.gettempdir(), tarball_local_filename)
+
+        print(f"Creating tarball {tarball_local_path} containing {local_wheel_filename} (at root) and 'agents/' dir (with 'platform_mcp_client/').")
+        with tarfile.open(tarball_local_path, "w:gz") as tar:
+            tar.add(copied_wheel_path, arcname=local_wheel_filename)
+            tar.add(temp_agents_root_in_tar_dir, arcname="agents")
+
+        gcs_tarball_path = os.path.join(bucket_prefix, 'reasoning_engine_dependencies', tarball_local_filename)
+        blob_tarball = bucket.blob(gcs_tarball_path)
+        blob_tarball.upload_from_filename(tarball_local_path)
+        dependency_files_gcs_uri = f"gs://{bucket_name}/{gcs_tarball_path}"
+        print(f"Uploaded dependency tarball to {dependency_files_gcs_uri}")
+        os.remove(tarball_local_path)
+
+    original_requirements_file_path = os.path.join(agents_content_base_path, "agents", "platform_mcp_client", "requirements.txt")
+    if not os.path.exists(original_requirements_file_path):
+         if os.path.basename(base_dir) == "platform_mcp_client" and os.path.exists(os.path.join(base_dir, "requirements.txt")):
+             original_requirements_file_path = os.path.join(base_dir, "requirements.txt")
+         else:
+             alt_req_path = os.path.join(base_dir, "platform_mcp_client", "requirements.txt")
+             if os.path.basename(base_dir) == "agents" and os.path.exists(alt_req_path):
+                 original_requirements_file_path = alt_req_path
+             else:
+                 raise FileNotFoundError(f"Original requirements file for platform_mcp_client not found. Checked: {original_requirements_file_path} and fallbacks based on base_dir: {base_dir}")
+
+    print(f"Reading original requirements from: {original_requirements_file_path}")
+    with open(original_requirements_file_path, "r") as f:
+        original_requirements_lines = f.readlines()
+
+    modified_requirements_lines = []
+    found_gcs_package = False
+    replaced_local_wheel = False
+
+    for line in original_requirements_lines:
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith('#'):
+            modified_requirements_lines.append(line)
+            continue
+        if "../" + local_wheel_filename in stripped_line or local_wheel_filename in stripped_line :
+            if not replaced_local_wheel: # Add only once
+                modified_requirements_lines.append(f"{local_wheel_filename}\n")
+                print(f"Modified requirements: Replaced '{stripped_line}' with '{local_wheel_filename}'.")
+                replaced_local_wheel = True
+            else: # If somehow listed multiple times
+                print(f"Modified requirements: Removed redundant reference to '{local_wheel_filename}'.")
+            continue
+
+        modified_requirements_lines.append(line)
+        if "google-cloud-storage" in stripped_line:
+            found_gcs_package = True
+
+    if not replaced_local_wheel:
+       print(f"Warning: Local wheel reference for '{local_wheel_filename}' not found to replace in {original_requirements_file_path}. Appending filename directly.")
+       modified_requirements_lines.append(f"{local_wheel_filename}\n")
+
+    if not found_gcs_package:
+        modified_requirements_lines.append("google-cloud-storage\n")
+        print("Modified requirements: Added 'google-cloud-storage'.")
+
+    modified_requirements_content = "".join(modified_requirements_lines)
+    modified_requirements_content = '\n'.join(filter(None, [l.strip() for l in modified_requirements_content.splitlines()])) + '\n'
 
 
-    print(f"Deploying {display_name} to Project: {project_id}, Location: {region}")
-    print(f"Using ADK Agent: {adk_agent_to_deploy}")
-    print(f"Using requirements list from: {requirements_file_path if os.path.exists(requirements_file_path) else (fallback_requirements_path if os.path.exists(fallback_requirements_path) else 'None found')}")
+    print("---- BEGIN Modified requirements.txt content for Platform MCP Client ----")
+    print(modified_requirements_content)
+    print("---- END Modified requirements.txt content ----")
 
-    remote_agent = agent_engines.create(
-        app=adk_agent_to_deploy,  # Pass the actual agent instance
+    gcs_requirements_filename = f"platform_mcp_client_requirements_modified_{uuid.uuid4()}.txt"
+    gcs_requirements_path = os.path.join(bucket_prefix, 'reasoning_engine_packages', gcs_requirements_filename)
+    blob_reqs = bucket.blob(gcs_requirements_path)
+    blob_reqs.upload_from_string(modified_requirements_content)
+    requirements_gcs_uri = f"gs://{bucket_name}/{gcs_requirements_path}"
+    print(f"Uploaded modified requirements to {requirements_gcs_uri}")
+
+    current_package_spec = ReasoningEngineSpec.PackageSpec(
+        pickle_object_gcs_uri=pickle_object_gcs_uri,
+        requirements_gcs_uri=requirements_gcs_uri,
+        dependency_files_gcs_uri=dependency_files_gcs_uri,
+        python_version="3.12"
+    )
+
+    reasoning_engine_spec = ReasoningEngineSpec(
+        package_spec=current_package_spec
+    )
+
+    gapic_reasoning_engine_config = ReasoningEngineGAPIC(
         display_name=display_name,
         description=description,
-        requirements=requirements_list, # Pass the list
-        # location=region, # location is implicitly handled by aiplatform.init()
-        # project=project_id # project_id is implicitly handled by aiplatform.init()
+        spec=reasoning_engine_spec
     )
-    print(f"Platform MCP Client Agent deployed: {remote_agent.name}")
-    # The console link relies on the region (location) being correctly passed or inferred.
-    # Since deploy_all.py calls aiplatform.init() with project_id and region, this should be fine.
-    print(f"View in console: https://console.cloud.google.com/vertex-ai/locations/{region}/agents/{remote_agent.name.split('/')[-1]}/versions?project={project_id}")
-    return remote_agent
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Deploy Platform MCP Client Agent to Vertex AI Agent Engine.")
-    parser.add_argument("--project_id", type=str, required=True, help="Google Cloud Project ID.")
-    parser.add_argument("--location", type=str, default="us-central1", help="Google Cloud region for deployment.")
-    # base_dir is not strictly needed for direct execution if requirements.txt is local,
-    # but added for consistency if we want to test the base_dir logic.
-    parser.add_argument("--base_dir", type=str, default=".", help="Base directory of the repository.")
+    print(f"Initializing GAPIC ReasoningEngineServiceClient with endpoint: {region}-aiplatform.googleapis.com")
+    client_options = {"api_endpoint": f"{region}-aiplatform.googleapis.com"}
+    gapic_client = reasoning_engine_service.ReasoningEngineServiceClient(client_options=client_options)
+    parent_path = f"projects/{project_id}/locations/{region}"
 
-
-    args = parser.parse_args()
-
-    # For direct execution, we need to initialize aiplatform here.
-    aiplatform.init(project=args.project_id, location=args.location)
-
-    deploy_platform_mcp_client_main_func(project_id=args.project_id, region=args.location, base_dir=args.base_dir)
+    print(f"Creating Platform MCP Client Reasoning Engine using GAPIC client with parent: {parent_path}...")
+    operation = gapic_client.create_reasoning_engine(
+        parent=parent_path,
+        reasoning_engine=gapic_reasoning_engine_config
+    )
+    print(f"Reasoning Engine creation operation started: {operation.operation.name}")
+    print("Waiting for operation to complete...")
+    deployed_agent_resource = operation.result()
+    print(f"Platform MCP Client Agent (Reasoning Engine) deployed successfully via GAPIC: {deployed_agent_resource.name}")
+    return deployed_agent_resource


### PR DESCRIPTION
…lient.

This aligns the deployment scripts for the orchestrate, platform_mcp_client, and social agents with the pattern used by the planner agent.

Here's a summary of the key changes I made for each affected agent (orchestrate, platform_mcp_client, social):
- I switched from `vertexai.agent_engines.create` to the GAPIC `ReasoningEngineServiceClient.create_reasoning_engine`.
- I implemented explicit pickling of the agent instance and uploaded it to GCS.
- I created a `dependencies.tar.gz` for each agent, which includes:
  - The agent's own source code directory (e.g., `agents/orchestrate/`).
  - Specific local directory dependencies (e.g., `agents/app/` for the orchestrate agent).
  - The common `a2a_common-0.1.0-py3-none-any.whl`.
  - An `agents/__init__.py` in the tarball's `agents/` directory.
- I uploaded the `dependencies.tar.gz` to GCS.
- I modified the agent's `requirements.txt` in memory during deployment to:
  - List local wheels by their filename (e.g., `a2a_common-0.1.0-py3-none-any.whl`).
  - Remove relative paths for packaged local dependencies.
  - Ensure `google-cloud-storage` is listed.
- I uploaded the modified requirements content to GCS.
- I utilized `ReasoningEngineSpec.PackageSpec` with the correct GCS URIs for the pickled agent, requirements file, and dependencies tarball.
- I set `python_version="3.12"` in `PackageSpec`.
- I removed old local execution/AdkApp setup code from the deploy scripts.

This standardization should improve the robustness and maintainability of the agent deployment process, ensuring consistent handling of dependencies and agent packaging for Vertex AI Reasoning Engines.