### PR TITLE
I've updated the Instavibe app to use the `PORT` environment variable…

### DIFF
--- a/instavibe/app.py
+++ b/instavibe/app.py
@@ -28,7 +28,12 @@ if not DATABASE_ID:
     raise ValueError("CRITICAL: COMMON_SPANNER_DATABASE_ID environment variable not set. Application cannot start.")
 PROJECT_ID = os.environ.get("COMMON_GOOGLE_CLOUD_PROJECT")
 APP_HOST = os.environ.get("INSTAVIBE_APP_HOST", "0.0.0.0")
-APP_PORT = os.environ.get("INSTAVIBE_APP_PORT","8080")
+
+# For Cloud Run, PORT is provided by the environment. Use it if available.
+# INSTAVIBE_APP_PORT can be a fallback for local dev or other environments.
+APP_PORT = os.environ.get("PORT") # Cloud Run's standard PORT variable
+if APP_PORT is None:
+    APP_PORT = os.environ.get("INSTAVIBE_APP_PORT", "8080") # Fallback to INSTAVIBE_APP_PORT, then 8080
 GOOGLE_MAPS_API_KEY = os.environ.get("INSTAVIBE_GOOGLE_MAPS_API_KEY")
 GOOGLE_MAPS_MAP_ID = os.environ.get('INSTAVIBE_GOOGLE_MAPS_MAP_ID') # Corrected variable name GOOGLE_MAPS_MAP_KEY to GOOGLE_MAPS_MAP_ID
 


### PR DESCRIPTION
… for Cloud Run compatibility.

The Flask application in `instavibe/app.py` now prioritizes the `PORT` environment variable, which will be provided by Cloud Run, for determining the listening port.

If `PORT` is not set, the application will fall back to `INSTAVIBE_APP_PORT` (from your .env file or environment), and then to a default of "8080". This ensures the application correctly binds to the port assigned by Cloud Run, while still allowing you to develop locally using `INSTAVIBE_APP_PORT`.