### PR TITLE
Fix: Add python-dateutil to instavibe/requirements.txt

### DIFF
--- a/instavibe/requirements.txt
+++ b/instavibe/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-spanner==3.54.0
 humanize==4.12.3
 gunicorn
 python-dotenv==1.0.1
+python-dateutil==2.9.0.post0


### PR DESCRIPTION
The instavibe app was failing to start on Cloud Run because of a ModuleNotFoundError for `dateutil.parser`. This was due to the `python-dateutil` package being missing from `instavibe/requirements.txt`, which is used when building the instavibe-app Docker image.

This commit adds `python-dateutil==2.9.0.post0` to ensure the dependency is included in the container.