### PR TITLE
Fix: Correct $PORT substitution in instavibe Dockerfile CMD

### DIFF
--- a/instavibe/Dockerfile
+++ b/instavibe/Dockerfile
@@ -22,4 +22,4 @@ ENV PYTHONPATH=/app
 EXPOSE 8080
 
 # --- Run the application ---
-CMD ["gunicorn", "--bind", "0.0.0.0:$PORT", "--workers", "2", "--threads", "4", "--worker-class", "gthread", "app:app"]
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:$PORT --workers 2 --threads 4 --worker-class gthread app:app"]


### PR DESCRIPTION
I changed the CMD instruction in `instavibe/Dockerfile` to use `sh -c`. This ensures that the `$PORT` environment variable, provided by Cloud Run, is correctly substituted into the gunicorn bind address.

Previously, the JSON array form of CMD prevented shell variable expansion, causing gunicorn to receive a literal '$PORT' as the port number and fail to start, leading to Cloud Run deployment errors.