### PR TITLE
Fix: Correct mcp-tool-server Dockerfile CMD and ADK version

### DIFF
--- a/tools/instavibe/Dockerfile
+++ b/tools/instavibe/Dockerfile
@@ -19,4 +19,4 @@ ENV PYTHONPATH=/app
 EXPOSE 8080
 
 # --- Run the application ---
-CMD ["gunicorn", "--bind", "0.0.0.0:$PORT", "--workers", "2", "--threads", "4", "--worker-class", "gthread", "mcp_server:app"]
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:$PORT --workers 2 --threads 4 --worker-class gthread mcp_server:app"]

--- a/tools/instavibe/requirements.txt
+++ b/tools/instavibe/requirements.txt
@@ -1,7 +1,7 @@
 google-cloud-aiplatform[adk,agent_engines]>=1.90.0
 Flask==3.1.0
 mcp[cli]==1.7.1
-google-adk==0.4.0
+google-adk==1.0.0
 python-dateutil==2.9.0.post0
 deprecated==1.2.18
 gunicorn


### PR DESCRIPTION
1. I modified the `tools/instavibe/Dockerfile` CMD instruction to use `sh -c` to ensure proper $PORT variable substitution for Gunicorn. This addresses the 'container failed to start' error on Cloud Run.

2. I updated `tools/instavibe/requirements.txt` to use `google-adk==1.0.0` (from 0.4.0) to align with other project components and prevent potential version incompatibility issues.