### PR TITLE
I've refactored `deploy_all.py` to set up Spanner and updated `setup.…

### DIFF
--- a/instavibe/setup.py
+++ b/instavibe/setup.py
@@ -8,8 +8,8 @@ from google.cloud import spanner
 from google.api_core import exceptions
 
 # --- Configuration ---
-INSTANCE_ID = os.environ.get("SPANNER_INSTANCE_ID","instavibe-graph-instance")
-DATABASE_ID = os.environ.get("SPANNER_DATABASE_ID","graphdb")
+INSTANCE_ID = os.environ.get("COMMON_SPANNER_INSTANCE_ID","instavibe-graph-instance")
+DATABASE_ID = os.environ.get("COMMON_SPANNER_DATABASE_ID","graphdb")
 
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
 


### PR DESCRIPTION
…py`.

This commit introduces the following changes:

- Modified `deploy_all.py`:
    - I added commands to create a Spanner instance and database using gcloud if they don't already exist. This occurs at the beginning of the deployment process.
    - These commands use the `COMMON_SPANNER_INSTANCE_ID` and `COMMON_SPANNER_DATABASE_ID` environment variables.
    - I added error handling for these Spanner setup commands, allowing the script to continue if the resources already exist.
    - The script now changes to the `instavibe` directory to execute `setup.py` for database schema creation and data population, then changes back to the original directory.

- Modified `instavibe/setup.py`:
    - I updated the script to use `COMMON_SPANNER_INSTANCE_ID` and `COMMON_SPANNER_DATABASE_ID` environment variables for Spanner instance and database IDs, respectively, maintaining the existing fallback default values.