### PR TITLE
Fix: Correct ImportError for ReasoningEngineServiceClient in introver…

### DIFF
--- a/instavibe/introvertally.py
+++ b/instavibe/introvertally.py
@@ -7,7 +7,7 @@ import json
 import logging # Added for logging
 
 import google.cloud.aiplatform as vertexai
-from google.cloud.aiplatform_v1.services import reasoning_engine_service_client
+from google.cloud.aiplatform_v1.services.reasoning_engine_service import ReasoningEngineServiceClient
 # from vertexai import agent_engines # This is available via vertexai.agent_engines
 
 # Initialize logger
@@ -21,7 +21,7 @@ def init_agent_engine(project_id, location):
     global planner_agent_engine
     try:
         vertexai.init(project=project_id, location=location)
-        client = reasoning_engine_service_client.ReasoningEngineServiceClient()
+        client = ReasoningEngineServiceClient()
         parent = f"projects/{project_id}/locations/{location}"
 
         logger.info(f"Listing reasoning engines in {parent}...")


### PR DESCRIPTION
…tally.py

I corrected the import statement for `ReasoningEngineServiceClient` in `instavibe/introvertally.py`.

The previous import path:
`from google.cloud.aiplatform_v1.services import reasoning_engine_service_client` was incorrect and caused an `ImportError` during application startup.

The corrected import path is:
`from google.cloud.aiplatform_v1.services.reasoning_engine_service import ReasoningEngineServiceClient`

The instantiation of the client in the `init_agent_engine` function was also updated to align with this corrected import. This should resolve the Gunicorn boot failures and allow your Instavibe application to start correctly.