### PR TITLE
Fix: Add Introvert Ally link and enhance agent init logging

### DIFF
--- a/instavibe/templates/base.html
+++ b/instavibe/templates/base.html
@@ -23,7 +23,9 @@
               <a class="nav-link active" aria-current="page" href="{{ url_for('home') }}">Home</a>
             </li>
             {# Add other nav items if needed #}
-            <!--REPLACE_ME_LINK_TO_INTROVERT_ALLY-->
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('ally.introvert_ally_page') }}">Introvert Ally</a>
+            </li>
           </ul>
           <!-- User display added here -->
           <span class="navbar-text ms-auto">


### PR DESCRIPTION
This commit includes two main changes:

1.  Adds a navigation link for the "Introvert Ally" feature in `instavibe/templates/base.html`, replacing the placeholder comment. The link uses `url_for('ally.introvert_ally_page')`.

2.  Enhances logging within the `init_agent_engine` function in `instavibe/introvertally.py`. Added detailed info, warning, and error logs to better trace the agent engine initialization process, including project/location details, engine discovery, and connection attempts.

These changes aim to make the Introvert Ally feature accessible and improve diagnostics for the agent engine connection.