### PR TITLE
Fix: Add COMMON_GOOGLE_CLOUD_LOCATION to instavibe-app

### DIFF
--- a/deploy_all.py
+++ b/deploy_all.py
@@ -591,6 +591,7 @@ def main(argv=None):
             f"INSTAVIBE_APP_PORT={os.environ.get('INSTAVIBE_APP_PORT', '8080')}",
             f"INSTAVIBE_GOOGLE_MAPS_API_KEY={os.environ.get('INSTAVIBE_GOOGLE_MAPS_API_KEY', '')}",
             f"INSTAVIBE_GOOGLE_MAPS_MAP_ID={os.environ.get('INSTAVIBE_GOOGLE_MAPS_MAP_ID', '')}",
+            f"COMMON_GOOGLE_CLOUD_LOCATION={os.environ.get('COMMON_GOOGLE_CLOUD_LOCATION', '')}"
         ]
         # Filter out vars that were not set in .env to avoid "VARNAME=" or "VARNAME=None"
         instavibe_env_vars_string = ",".join(


### PR DESCRIPTION
The instavibe-app Cloud Run service was missing the COMMON_GOOGLE_CLOUD_LOCATION environment variable, which is required by instavibe/introvertally.py to initialize the agent engine.

This change modifies deploy_all.py to include
COMMON_GOOGLE_CLOUD_LOCATION in the environment variables passed to the instavibe-app service during deployment.

This ensures that the planner_agent_engine can be initialized correctly, resolving the 'Agent engine not initialized' error.