### PR TITLE
Fix: Use global client endpoint for listing Reasoning Engines

### DIFF
--- a/instavibe/introvertally.py
+++ b/instavibe/introvertally.py
@@ -25,11 +25,10 @@ def init_agent_engine(project_id, location):
         vertexai.init(project=project_id, location=location)
 
         logger.info("Initializing ReasoningEngineServiceClient")
-        client_options = {"api_endpoint": "aiplatform.googleapis.com"}
-        client = ReasoningEngineServiceClient(client_options=client_options)
-        parent = f"projects/{project_id}/locations/global"
+        client = ReasoningEngineServiceClient()
+        parent = f"projects/{project_id}/locations/{location}"
 
-        logger.info(f"Listing reasoning engines in project {project_id}, location global")
+        logger.info(f"Listing reasoning engines in project {project_id}, location {location}")
         engines = client.list_reasoning_engines(parent=parent)
 
         target_engine_display_name = "Planner Agent"

--- a/instavibe/introvertally.py
+++ b/instavibe/introvertally.py
@@ -25,7 +25,8 @@ def init_agent_engine(project_id, location):
         vertexai.init(project=project_id, location=location)
 
         logger.info("Initializing ReasoningEngineServiceClient")
-        client = ReasoningEngineServiceClient()
+        client_options = {"api_endpoint": "aiplatform.googleapis.com"}
+        client = ReasoningEngineServiceClient(client_options=client_options)
         parent = f"projects/{project_id}/locations/global"
 
         logger.info(f"Listing reasoning engines in project {project_id}, location global")


### PR DESCRIPTION
The agent engine initialization was still failing with a 400 error indicating a mismatch between the location ID and the endpoint, even when using a 'global' parent path for listing reasoning engines.

This change modifies instavibe/introvertally.py in init_agent_engine to explicitly initialize ReasoningEngineServiceClient with client_options set to {"api_endpoint": "aiplatform.googleapis.com"} when listing engines with the global parent path.

This ensures the client communicates with the global endpoint, aligning with the global scope of the listing operation. The initial vertexai.init() still uses the regional location for other potential Vertex AI operations.