### PR TITLE
Refactor agent_engine_app.py for custom container deployment

### DIFF
--- a/agents/app/agent_engine_app.py
+++ b/agents/app/agent_engine_app.py
@@ -19,11 +19,35 @@ from app.utils.gcs import create_bucket_if_not_exists
 # from app.utils.typing import Feedback # Feedback class removed
 # from vertexai.preview.reasoning_engines import AdkApp # AdkApp removed
 
-# Import the LangGraph app builder
-from agents.app.graph_builder import build_graph
+# --- Custom Container Deployment Workflow ---
+# This script deploys a custom Docker container to Vertex AI Agent Engines.
+# The overall workflow is:
+# 1. Develop your LangGraph application, wrapped in a FastAPI server (e.g., as in `agents/main.py`).
+# 2. Create a Dockerfile (e.g., `agents/Dockerfile`) to package this FastAPI application.
+#    - Ensure the Dockerfile copies all necessary code (FastAPI app, LangGraph app, common utilities).
+#    - Ensure it installs all dependencies from a `requirements.txt`.
+#    - Ensure the container exposes the correct port (e.g., 8080) and runs the FastAPI server on 0.0.0.0.
+# 3. Build your Docker image:
+#    `docker build -t YOUR_IMAGE_NAME:TAG -f agents/Dockerfile .` (assuming context is repo root)
+#    or if context is `agents/` directory:
+#    `docker build -t YOUR_IMAGE_NAME:TAG -f Dockerfile .`
+# 4. Tag your Docker image for Artifact Registry (or another registry):
+#    `docker tag YOUR_IMAGE_NAME:TAG YOUR_REGION-docker.pkg.dev/YOUR_PROJECT_ID/YOUR_REPO_NAME/YOUR_IMAGE_NAME:TAG`
+# 5. Push the image to Artifact Registry:
+#    `docker push YOUR_REGION-docker.pkg.dev/YOUR_PROJECT_ID/YOUR_REPO_NAME/YOUR_IMAGE_NAME:TAG`
+#    (Ensure you have authenticated Docker with gcloud: `gcloud auth configure-docker YOUR_REGION-docker.pkg.dev`)
+# 6. Run this script, providing the full image URI obtained in step 5 as the --container-image-uri argument.
+#
+# Note: This script assumes the container image is already built and pushed to a registry.
+# The `container_spec` used in this script for `agent_engines.create()` is based on
+# common patterns for custom containers on Vertex AI. Refer to the official
+# Vertex AI Agent Engines documentation for the precise schema if available.
+# ---
 
 # Load environment variables from the root .env file
 load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), '..', '..', '.env'))
+# build_graph is no longer called directly in this script when using custom containers.
+# from agents.app.graph_builder import build_graph
 
 GOOGLE_CLOUD_PROJECT = os.environ.get("COMMON_GOOGLE_CLOUD_PROJECT")
 
@@ -33,12 +57,11 @@ GOOGLE_CLOUD_PROJECT = os.environ.get("COMMON_GOOGLE_CLOUD_PROJECT")
 def deploy_agent_engine_app(
     project: str,
     location: str,
+    container_image_uri: str, # New parameter for the Docker image
     agent_name: str | None = None,
-    requirements_file: str = "requirements.txt",
-    extra_packages: list[str] = ["./agents", "./app", "./common", "./a2a_common-0.1.0-py3-none-any.whl"], # Adjusted paths
     env_vars: dict[str, str] | None = None,
-) -> agent_engines.AgentEngine | None: # Return type can be None if deployment is stubbed
-    """Deploy the LangGraph agent engine app to Vertex AI."""
+) -> agent_engines.AgentEngine | None:
+    """Deploy the LangGraph agent engine app to Vertex AI using a custom container."""
 
     staging_bucket = f"gs://{project}-agent-engine"
 
@@ -47,121 +70,156 @@ def deploy_agent_engine_app(
     )
     vertexai.init(project=project, location=location, staging_bucket=staging_bucket)
 
-    # Read requirements
-    with open(requirements_file) as f:
-        requirements = f.read().strip().split("\n")
+    # Requirements and extra_packages are now part of the Docker image build process,
+    # not directly used in this deployment function.
 
-    # Instantiate the LangGraph application
-    # This application should be a runnable/callable that Vertex AI Agent Engines can serve.
-    # LangGraph's `app.compile()` returns a `CompiledGraph` which is runnable.
-    try:
-        langgraph_app = build_graph()
-        logging.info(f"LangGraph application built successfully: {type(langgraph_app)}")
-    except Exception as e:
-        logging.error(f"Failed to build the LangGraph application: {e}", exc_info=True)
-        # Cannot proceed with deployment if the app itself fails to build.
-        return None
+    # The LangGraph application is assumed to be packaged within the Docker container
+    # specified by `container_image_uri`. This script no longer builds it directly.
 
-
-    # Common configuration for both create and update operations
-    # CRITICAL CHANGE: The 'agent_engine' key now needs to point to something
-    # compatible with agent_engines.create/update.
-    # If LangGraph's compiled app is not directly compatible, this is where
-    # a wrapper (e.g., FastAPI app) or a different deployment strategy is needed.
-
-    # For now, we will optimistically pass the langgraph_app.
-    # If this fails during actual deployment (which is likely if AgentEngine expects an ADK type),
-    # then the deployment part of this function needs to be re-evaluated.
-    # The goal of this subtask is to remove ADK from *this* codebase.
-    # Actual deployment compatibility is a subsequent concern.
-
+    # --- Agent Configuration for Custom Container ---
+    # This configuration assumes a structure for custom container deployment
+    # based on common patterns in Vertex AI (e.g., custom prediction routines).
+    # IMPORTANT: Verify this structure against the official documentation for
+    # `vertexai.agent_engines` when available for custom container deployment.
     agent_config: Dict[str, Any] = {
-        # "agent_engine": langgraph_app, # This is the optimistic approach
         "display_name": agent_name,
-        "description": "Orchestrator agent built with LangGraph", # Updated description
-        "extra_packages": extra_packages,
-        "requirements": requirements,
-        # "env_vars": env_vars, # Handled by Reasoning Engine tool for remote serving if needed, or by container env
+        "description": "Orchestrator agent built with LangGraph, served via custom container.",
+        # "tool_contract": {
+        #     # This section is speculative. If the Agent Engine framework requires
+        #     # explicit tool definitions at the engine level (even for custom containers),
+        #     # they would be defined here. For a generic FastAPI backend exposing
+        #     # LangGraph, this might be minimal or auto-discovered by the framework
+        #     # by calling an endpoint on the container.
+        # },
+        "default_version_config": { # Assuming a versioning system
+            "version_display_name": "v1", # Or some other version identifier
+            "container_spec": {  # Key part for custom container deployment
+                "image_uri": container_image_uri,
+                # "command": [],  # Optional: Override Docker CMD
+                # "args": [],     # Optional: Override Docker CMD
+                "env": [],      # Will be populated from env_vars if provided
+                "ports": [
+                    {"container_port": int(os.environ.get("CONTAINER_PORT", 8080))} # Port container listens on
+                ],
+                # These routes are common for Vertex AI custom containers.
+                # Ensure your FastAPI application (or other serving framework) in the container
+                # exposes these routes accordingly.
+                "predict_route": "/invoke_graph", # Route for predictions/invocations (e.g., to your LangGraph)
+                "health_route": "/"             # Route for health checks (e.g., FastAPI root)
+            }
+        }
+        # "environment_variables" at the top level might be deprecated if all env vars
+        # are now part of container_spec.env. For clarity, we'll populate container_spec.env.
     }
-    if env_vars: # env_vars are passed to the ReasoningEngine resource
-        agent_config["environment_variables"] = env_vars
 
+    if env_vars:
+        # Format for container_spec.env is typically a list of {"name": "KEY", "value": "VALUE"}
+        agent_config["default_version_config"]["container_spec"]["env"] = [
+            {"name": k, "value": v} for k, v in env_vars.items()
+        ]
 
     # Logging the configuration for debugging
-    log_config_summary = {k: v for k, v in agent_config.items() if k != "agent_engine"}
-    log_config_summary["agent_engine_type"] = type(langgraph_app).__name__
-    logging.info(f"Agent config for deployment (summary): {json.dumps(log_config_summary, indent=2, default=str)}")
+    # Remove sensitive parts or large structures if necessary for production logs.
+    log_config_summary = {
+        "display_name": agent_config.get("display_name"),
+        "description": agent_config.get("description"),
+        "deployment_type": "custom_container",
+        "image_uri": container_image_uri,
+        "default_version_config": {
+            "version_display_name": agent_config.get("default_version_config", {}).get("version_display_name"),
+            "container_spec": {
+                "image_uri": agent_config.get("default_version_config", {}).get("container_spec", {}).get("image_uri"),
+                "ports": agent_config.get("default_version_config", {}).get("container_spec", {}).get("ports"),
+                "predict_route": agent_config.get("default_version_config", {}).get("container_spec", {}).get("predict_route"),
+                "health_route": agent_config.get("default_version_config", {}).get("container_spec", {}).get("health_route"),
+                "env_count": len(agent_config.get("default_version_config", {}).get("container_spec", {}).get("env", [])),
+            }
+        }
+    }
+    logging.info(f"Agent config for custom container deployment (summary): {json.dumps(log_config_summary, indent=2, default=str)}")
 
+    logging.info("Attempting to deploy agent engine with custom container...")
+    logging.warning("IMPORTANT: Ensure the provided `container_image_uri` is accessible and correctly configured for Vertex AI Agent Engines.")
+    logging.warning("The `container_spec` structure used here is based on common Vertex AI patterns and may need verification against official SDK documentation.")
 
-    # --- DEPLOYMENT STUB ---
-    # The following `agent_engines.create/update` calls will likely fail if `langgraph_app`
-    # is not a type that Vertex AI Agent Engines directly supports for the `agent_engine` field
-    # (e.g., if it expects an AdkApp or a specific interface for serving).
-    #
-    # To make this script ADK-free as per the subtask goal, we will comment out
-    # the actual deployment calls for now. The script will be runnable without ADK,
-    # but deployment will need to be addressed based on how LangGraph apps are
-    # hosted on Vertex AI Agent Engines (e.g., custom container, specific serving interface).
-
-    logging.warning("IMPORTANT: The actual deployment calls (`agent_engines.create/update`) are currently STUBBED OUT.")
-    logging.warning("The LangGraph application `langgraph_app` needs to be packaged or served in a way that is compatible with Vertex AI Agent Engines.")
-    logging.warning("This might involve creating a custom container with a serving layer (e.g., FastAPI) for the LangGraph app, "
-                    "or using a future Vertex AI feature that directly supports LangGraph applications.")
-    logging.info("To proceed with actual deployment, you would need to replace the stubbed section with a compatible deployment mechanism.")
-
-    # Placeholder for where remote_agent would be defined after successful deployment
     remote_agent = None
+    try:
+        existing_agents = list(agent_engines.list(filter=f"display_name='{agent_name}'")) # Ensure agent_name is quoted for filter
+        if existing_agents:
+            logging.info(f"Attempting to update existing agent: {agent_name} with ID: {existing_agents[0].name}...")
+            # For update, the 'name' of the existing agent resource is required.
+            # The agent_config should contain the desired state, including the new container_spec.
+            # Note: The `update` method might have specific requirements for how versions are handled.
+            # This example assumes updating the default version or creating a new one as per `default_version_config`.
+            # The SDK might require `agent_config` to be passed to `update_version` or similar.
+            # This is a simplified representation.
+            # It's also possible that `update` only takes specific fields rather than the whole config.
+            # For a robust update, one might need to:
+            # 1. Get the existing agent.
+            # 2. Create a new version with the new container_spec.
+            # 3. Update the agent to point to this new version as default.
+            # However, the `update` method on the agent object itself might simplify this.
 
-    # STUBBED DEPLOYMENT SECTION START
-    # try:
-    #     existing_agents = list(agent_engines.list(filter=f"display_name={agent_name}"))
-    #     if existing_agents:
-    #         logging.info(f"Attempting to update existing agent: {agent_name}...")
-    #         # Ensure agent_config for update includes the 'name' of the existing agent
-    #         agent_config_for_update = agent_config.copy()
-    #         agent_config_for_update["name"] = existing_agents[0].name
-    #         # The 'agent_engine' field must be compatible.
-    #         # This is where direct passage of langgraph_app might be an issue.
-    #         # For a true update, one might need to create a new ReasoningEngine version
-    #         # with the updated langgraph_app and then update the AgentEngine to point to it.
-    #         # This is complex and depends on Vertex AI specifics.
-    #         # For now, we assume if `create` works, `update` would need similar compatibility.
-    #         # remote_agent = existing_agents[0].update(**agent_config) # This line is problematic if langgraph_app isn't directly usable.
-    #         logging.warning(f"Update for agent '{agent_name}' is STUBBED. Requires compatible agent_engine type.")
-    #         remote_agent = existing_agents[0] # Simulate getting the agent
-    #     else:
-    #         logging.info(f"Attempting to create new agent: {agent_name}...")
-    #         # The `agent_engine` field here is `langgraph_app`. This is the key test.
-    #         # If this is not supported, the deployment will fail here.
-    #         # remote_agent = agent_engines.create(**agent_config)
-    #         logging.warning(f"Create for agent '{agent_name}' is STUBBED. Requires compatible agent_engine type.")
-    #         # Simulate a successful creation for metadata purposes if needed by downstream code
-    #         # This would require knowing the expected structure of a remote_agent object.
-    #
-    # except google.api_core.exceptions.InvalidArgument as e:
-    #     logging.error(f"!!! InvalidArgument error during (stubbed) agent deployment for '{agent_name}': {e}")
-    #     logging.error(f"--- Agent Configuration Summary: {json.dumps(log_config_summary, indent=2, default=str)} ---")
-    #     raise
-    # except Exception as e:
-    #     logging.error(f"An unexpected error occurred during (stubbed) agent deployment for '{agent_name}': {e}", exc_info=True)
-    #     raise
-    # STUBBED DEPLOYMENT SECTION END
+            # Let's assume `update` can take a modified config. We need the resource name.
+            update_payload = agent_config.copy() # Start with the full desired config
+            # update_payload["name"] = existing_agents[0].name # The resource name for the update call
 
-    if remote_agent and hasattr(remote_agent, 'resource_name'): # Check if a simulated or real remote_agent object exists
+            # The update method is on the agent object, not a static method.
+            # existing_agents[0].update(???) -> The SDK here is a bit of a guess.
+            # Let's assume we pass what can be updated.
+            # `display_name`, `description`, `default_version_config` are common.
+
+            # Simplification: Vertex AI Agent Engine's update method might not allow full config pass-through.
+            # It might expect specific parameters or a structured update request.
+            # For now, this is a placeholder for the correct update logic.
+            # A common pattern for updates is to pass only the fields that need changing.
+            # However, to update a container, you typically update a "version" of the agent.
+
+            # Given the uncertainty of the `update` method's exact signature for custom containers
+            # and versioning, we will focus on `create` and log a warning for `update`.
+            # A real implementation would require consulting the SDK for how to properly roll out a new container version.
+
+            logging.warning(f"Update logic for agent '{agent_name}' with a new custom container is complex and SDK-dependent (especially around versioning).")
+            logging.warning("This script will attempt a simplified update if the agent exists, but it might not correctly roll out the new container version.")
+            logging.warning("Consider manually managing versions or consult SDK for advanced update patterns.")
+
+            # This is a guess: the update method might take the new default_version_config.
+            # Or it might require creating a new AgentVersion and then setting it.
+            # For now, let's assume the `update` method of an `AgentEngine` instance can refresh its configuration.
+            # This is highly speculative.
+            remote_agent = existing_agents[0].update(default_version_config=agent_config["default_version_config"])
+            logging.info(f"Agent '{agent_name}' update call attempted.")
+
+        else:
+            logging.info(f"Attempting to create new agent: {agent_name} with custom container...")
+            remote_agent = agent_engines.create(**agent_config)
+            logging.info(f"Agent '{agent_name}' create call attempted successfully.")
+
+    except google.api_core.exceptions.InvalidArgument as e:
+        logging.error(f"!!! InvalidArgument error during agent deployment for '{agent_name}': {e}")
+        logging.error(f"--- Agent Configuration Summary used: {json.dumps(log_config_summary, indent=2, default=str)} ---")
+        logging.error("--- Please verify the `agent_config` structure, especially `container_spec`, against Vertex AI Agent Engines documentation for custom containers. ---")
+        raise
+    except Exception as e:
+        logging.error(f"An unexpected error occurred during agent deployment for '{agent_name}': {e}", exc_info=True)
+        raise
+
+    if remote_agent and hasattr(remote_agent, 'resource_name'):
         config = {
             "remote_agent_engine_id": remote_agent.resource_name,
             "deployment_timestamp": datetime.datetime.now().isoformat(),
-            "status": "STUBBED_DEPLOYMENT" # Indicate that this was not a live deployment
+            "status": "ATTEMPTED_DEPLOYMENT_CUSTOM_CONTAINER", # Updated status
+            "image_uri": container_image_uri,
+            "agent_name": agent_name
         }
         config_file = "deployment_metadata.json"
         with open(config_file, "w") as f:
             json.dump(config, f, indent=2)
-        logging.info(f"Deployment metadata (stubbed) written to {config_file}")
+        logging.info(f"Deployment metadata written to {config_file}")
     else:
-        logging.warning("No remote_agent object available (deployment was stubbed). Skipping metadata file.")
+        logging.warning("No remote_agent object returned from deployment call or it lacks 'resource_name'. Skipping metadata file.")
 
-
-    return remote_agent # This will be None if deployment is stubbed
+    return remote_agent
 
 
 if __name__ == "__main__":
@@ -171,8 +229,7 @@ if __name__ == "__main__":
     )
     import argparse
 
-    parser = argparse.ArgumentParser(description="Deploy LangGraph agent engine app to Vertex AI (Deployment calls are STUBBED)")
-    # ... (rest of argparse setup remains the same) ...
+    parser = argparse.ArgumentParser(description="Deploy LangGraph agent engine app to Vertex AI using a custom container.")
     parser.add_argument(
         "--project",
         default=GOOGLE_CLOUD_PROJECT,
@@ -185,23 +242,19 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--agent-name",
-        default="orchestrate-agent-langgraph", # Modified default name
+        default="orchestrate-agent-custom-container",
         help="Name for the agent engine",
     )
+    # The user must provide the full URI of the pre-built and pushed Docker container image.
+    # Example: gcr.io/your-project-id/your-image-name:tag or YOUR_REGION-docker.pkg.dev/YOUR_PROJECT_ID/YOUR_REPO_NAME/YOUR_IMAGE_NAME:TAG
     parser.add_argument(
-        "--requirements-file",
-        default="./requirements.txt",
-        help="Path to requirements.txt file",
-    )
-    parser.add_argument(
-        "--extra-packages",
-        nargs="+",
-        default=["./agents", "./app", "./common", "./a2a_common-0.1.0-py3-none-any.whl"], # Adjusted paths
-        help="Additional packages to include",
+        "--container-image-uri",
+        required=True,
+        help="URI of the Docker container image for deployment (e.g., gcr.io/your-project/your-agent-image:latest)",
     )
     parser.add_argument(
         "--set-env-vars",
-        help="Semicolon-separated list of environment variables in KEY=VALUE format for the agent engine deployment",
+        help="Semicolon-separated list of environment variables in KEY=VALUE format for the agent engine deployment (e.g., 'VAR1=value1;VAR2=value2')",
     )
     args = parser.parse_args()
 
@@ -213,34 +266,86 @@ if __name__ == "__main__":
             if not pair: continue
             try:
                 key, value = pair.split("=", 1)
-                env_vars_dict[key.strip()] = value
-                logging.info(f"Parsed environment variable for agent engine deployment: {key.strip()}={value}")
+                env_vars_dict[key.strip()] = value.strip() # Also strip value
+                logging.info(f"Parsed environment variable for agent engine deployment: {key.strip()}={value.strip()}")
             except ValueError:
                 logging.warning(f"Skipping invalid environment variable pair for deployment: '{pair}'")
 
     effective_project = args.project
     if not effective_project:
-        _, effective_project = google.auth.default()
-        logging.info(f"Using default GCP project: {effective_project}")
+        try:
+            _, effective_project = google.auth.default()
+            logging.info(f"Using default GCP project: {effective_project}")
+        except google.auth.exceptions.DefaultCredentialsError:
+            logging.error("GCP project not specified and default credentials not found. Please set --project or configure gcloud.")
+            exit(1)
 
 
-    logging.info("""
-    ╔══════════════════════════════════════════════════════════════════════════════════╗
-    ║                                                                                      ║
-    ║   🔄 REFRAINING FROM ACTUAL DEPLOYMENT - ADK REMOVAL & LANGGRAPH INTEGRATION 🔄     ║
-    ║   The script will build the LangGraph app and prepare a configuration,             ║
-    ║   but the `agent_engines.create/update` calls are STUBBED OUT.                     ║
-    ║   Review logs for compatibility notes for Vertex AI Agent Engines.                 ║
-    ║                                                                                      ║
-    ╚══════════════════════════════════════════════════════════════════════════════════╝
+    logging.info(f"""
+    ╔═════════════════════════════════════════════════════════════════════════════════════════╗
+    ║                                                                                         ║
+    ║   🚀 ATTEMPTING CUSTOM CONTAINER DEPLOYMENT TO VERTEX AI AGENT ENGINES 🚀                 ║
+    ║   Project: {effective_project}                                                               ║
+    ║   Location: {args.location}                                                                 ║
+    ║   Agent Name: {args.agent_name}                                                             ║
+    ║   Container Image URI: {args.container_image_uri}                                           ║
+    ║   Environment Variables: {env_vars_dict if env_vars_dict else "None"}                                       ║
+    ║                                                                                         ║
+    ║   IMPORTANT: Ensure the container image is accessible and the `container_spec` in         ║
+    ║   this script aligns with Vertex AI Agent Engines SDK requirements.                       ║
+    ║   The SDK calls for `agent_engines.create()` and `update()` are now active.               ║
+    ║                                                                                         ║
+    ╚═════════════════════════════════════════════════════════════════════════════════════════╝
     """)
 
-    deploy_agent_engine_app(
-        project=effective_project,
-        location=args.location,
-        agent_name=args.agent_name,
-        requirements_file=args.requirements_file,
-        extra_packages=args.extra_packages,
-        env_vars=env_vars_dict,
-    )
-    logging.info("Script finished. Deployment calls were stubbed.")
+    try:
+        deploy_agent_engine_app(
+            project=effective_project,
+            location=args.location,
+            agent_name=args.agent_name,
+            container_image_uri=args.container_image_uri,
+            env_vars=env_vars_dict,
+        )
+        logging.info("Script finished. Check logs for deployment status.")
+    except Exception as e:
+        logging.error(f"Deployment script failed: {e}", exc_info=True)
+        # Optionally, re-raise or exit with error code
+        # exit(1)
+
+# --- Conceptual Testing Strategy ---
+# To test this script conceptually (without incurring costs or requiring full GCP setup for automated tests):
+#
+# 1.  **Unit Test `deploy_agent_engine_app` (Mocked SDK):**
+#     *   Write a unit test for the `deploy_agent_engine_app` function.
+#     *   Mock the `vertexai.init` and `vertexai.agent_engines` client calls (e.g., `agent_engines.create`, `agent_engines.list`, `agent_engines.update`).
+#     *   Verify that the function constructs the `agent_config` (especially the `container_spec`) correctly based on input parameters (project, location, agent_name, container_image_uri, env_vars).
+#     *   Check that the correct parameters are passed to the mocked SDK calls.
+#     *   Ensure appropriate logging occurs.
+#
+# 2.  **Command-Line Invocation Test (Dry Run Mindset):**
+#     *   Prepare a sample Docker image URI (it doesn't have to be a real, working image for this test, just a correctly formatted URI string).
+#     *   Run the script with dummy values for project, location, agent name, and the sample image URI.
+#       `python agents/app/agent_engine_app.py --project "test-project" --location "us-central1" --agent-name "test-container-agent" --container-image-uri "us-central1-docker.pkg.dev/test-project/test-repo/test-image:latest" --set-env-vars "MY_VAR=my_value;ANOTHER_VAR=another_value"`
+#     *   Observe the log output:
+#         *   Verify that the script parses arguments correctly.
+#         *   Check that the `agent_config` logged to the console matches expectations (image URI, env vars mapped correctly into `container_spec.env`, etc.).
+#         *   Confirm that the script attempts to call `agent_engines.create` or `agent_engines.update`.
+#         *   If there are authentication errors (expected if not running with valid gcloud auth), these can be ignored for this conceptual test, as the goal is to see the script's logic flow up to the SDK call.
+#
+# 3.  **Verify Docker Container Independently (Optional but Recommended):**
+#     *   Separately, ensure the Docker container (built from `agents/Dockerfile` and `agents/main.py`) runs correctly locally.
+#       `docker run -p 8080:8080 YOUR_IMAGE_NAME:TAG`
+#     *   Test that the FastAPI server starts and that the `/` (health) and `/invoke_graph` (predict) endpoints are responsive using `curl` or a tool like Postman.
+#     *   This step ensures the artifact being deployed is functional before attempting cloud deployment.
+#
+# 4.  **Actual Deployment Test (Manual, Staged):**
+#     *   Perform a manual deployment using the script against a non-production/test GCP project.
+#     *   Use a real, pushed Docker image URI.
+#     *   Monitor the Google Cloud Console (Vertex AI > Agent Engines) to see if the agent resource is created or updated.
+#     *   Check logs in Cloud Logging for any deployment errors from the Vertex AI platform.
+#     *   If successful, attempt to invoke the deployed agent engine (how this is done depends on the Agent Engine's capabilities - it might provide an endpoint or require client code).
+#
+# Note: Full end-to-end automated testing would require a dedicated test project,
+# service accounts, and cleanup routines for created resources.
+# The strategy above focuses on testing the script's logic and prerequisites.
+# ---


### PR DESCRIPTION
I've modified `agents/app/agent_engine_app.py` to deploy a custom Docker container to Vertex AI Agent Engines, rather than attempting to deploy a raw LangGraph application object.

Key changes:
- The `deploy_agent_engine_app` function now accepts a `container_image_uri` parameter.
- I removed direct LangGraph application building within the script; the application is expected to be pre-built into the container.
- I updated `agent_config` to use an assumed `container_spec` structure suitable for custom container deployment on Vertex AI. This includes image URI, port, health/predict routes, and environment variables.
- I added extensive comments detailing the assumed `container_spec` structure, the required Docker build/push workflow, and a conceptual testing strategy.
- I updated the command-line arguments to accept `--container-image-uri` and removed obsolete arguments related to local packaging.
- The deployment calls (`agent_engines.create/update`) are now active, targeting custom container deployment.

This change addresses the issue of the previously stubbed deployment logic by implementing a more viable approach for Vertex AI Agent Engines, assuming it supports custom containerized agents. You should verify the exact schema for `container_spec` against official documentation when available.