### PR TITLE
Fix(platform): Correct platform_mcp_client deployment imports

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,42 @@
+# Analysis of Agent Deployment Logic
+
+This document summarizes the findings from analyzing the agent deployment mechanisms within this repository, specifically addressing whether the code contains stubbed-out deployment logic for Vertex AI Agent Engines.
+
+## Deployment to Vertex AI Reasoning Engines
+
+The primary deployment mechanism observed across all agents (`Orchestrate`, `Planner`, `Social`, `PlatformMCPClient`) involves packaging the agent as a Python object and deploying it to **Vertex AI Reasoning Engines** (using `google.cloud.aiplatform_v1.services.reasoning_engine_service`).
+
+The process typically includes:
+1.  **Pickling Agent Instances**: An instance of the agent class (e.g., `OrchestrateServiceAgent`, `PlannerAgent`) is serialized using `cloudpickle`.
+2.  **Dependency Packaging**:
+    *   A common local wheel (`a2a_common-0.1.0-py3-none-any.whl`) is included.
+    *   Agent-specific source code and its `requirements.txt` are packaged. The `requirements.txt` is often modified to include the local wheel and `google-cloud-storage`.
+    *   These dependencies are bundled into a `.tar.gz` file.
+3.  **Google Cloud Storage (GCS)**: The pickled agent, the dependency tarball, and the modified `requirements.txt` are uploaded to GCS.
+4.  **Reasoning Engine Creation**: The `ReasoningEngineServiceClient` (GAPIC client) is used to create a new `ReasoningEngine` on Vertex AI, configured with URIs pointing to the GCS artifacts.
+
+**Conclusion on "Stubbed-out Logic"**: The deployment scripts (`deploy_*.py` for each agent) are **not stubbed-out**. They represent a complete and functional, albeit manual, process for deploying these Python agents to Vertex AI Reasoning Engines.
+
+## LangGraph Application Deployment
+
+A key aspect of the original issue was the deployment of "raw LangGraph applications."
+
+*   **No Direct Deployment of Raw Graphs**: The system does **not** directly pickle and deploy compiled LangGraph objects (e.g., the output of LangGraph's `compile()` method).
+*   **Wrapper Classes**: For agents that utilize LangGraph (e.g., `OrchestrateServiceAgent`, `SocialAgent`, `PlatformAgent`), the LangGraph application is encapsulated within a wrapper Python class. This wrapper class instance is what gets pickled and deployed. The wrapper provides an interface (typically an `async_query(self, query: str, **kwargs)` method) that the Reasoning Engine invokes. This is a sound architectural pattern as it decouples the core graph logic from the serving interface and allows for pre/post-processing.
+*   **Non-LangGraph Agents**: Some agents (e.g., `PlannerAgent`) are not LangGraph-based but are deployed using the same pickling mechanism, indicating the flexibility of the deployment approach for various Python objects that conform to the expected invocation signature.
+
+## Vertex AI Agent Engines vs. Reasoning Engines
+
+The issue specifically mentions "Vertex AI **Agent Engines**." The current deployment scripts target "Vertex AI **Reasoning Engines**."
+
+*   If "Agent Engines" are a distinct service or layer built on top of (or separate from) "Reasoning Engines" and come with their own SDK, specific base classes, or deployment paradigms (especially for LangGraph applications), then the current codebase **does not reflect such specific integration.**
+*   The current approach provides a generic way to serve Python objects. If "Agent Engines" require adherence to a more structured framework for features like standardized state management, tool invocation, observability, or managed LangGraph runtimes, then **further wrappers or platform-specific SDK adoption would be necessary.** The current wrappers are sufficient for the "Reasoning Engine" deployment but might not meet all requirements or leverage all features of a dedicated "Agent Engine" platform if it differs significantly.
+
+## Minor Observations
+
+*   **Dependency Packaging Inconsistencies**: There are slight variations in how the `agents/` subdirectory and its contents are packaged into the dependency tarball across the different `deploy_*.py` scripts. Standardizing this could simplify maintenance.
+*   **Import Bug (Fixed)**: An import bug was identified and fixed in `agents/platform_mcp_client/__init__.py` and `agents/platform_mcp_client/deploy.py` to ensure `PlatformAgent` could be correctly instantiated and deployed.
+
+## Summary
+
+The existing agent code does not contain "stubbed-out" deployment logic for getting agents onto Vertex AI Reasoning Engines; this process is implemented. LangGraph applications are appropriately wrapped. The main question remains whether "Vertex AI Agent Engines" imply a different set of requirements or SDKs not currently in use. If so, adaptation would be needed.

--- a/agents/platform_mcp_client/__init__.py
+++ b/agents/platform_mcp_client/__init__.py
@@ -1,1 +1,4 @@
-from . import agent
+from .platform_agent import PlatformAgent
+
+# This instance will be imported by the deployment script
+root_agent = PlatformAgent()

--- a/agents/platform_mcp_client/deploy.py
+++ b/agents/platform_mcp_client/deploy.py
@@ -14,7 +14,7 @@ from google.cloud import storage
 import google.auth # For google.auth.exceptions
 
 # Import the agent module that contains the `root_agent`
-from agents.platform_mcp_client import agent as platform_mcp_client_agent_module
+from agents.platform_mcp_client import root_agent
 from dotenv import load_dotenv # For loading .env file
 
 # Load environment variables from the root .env file
@@ -49,7 +49,7 @@ def deploy_platform_mcp_client_main_func(project_id: str, region: str, base_dir:
         raise
 
     # The agent to pickle is platform_mcp_client_agent_module.root_agent
-    agent_instance_to_pickle = platform_mcp_client_agent_module.root_agent
+    agent_instance_to_pickle = root_agent
     if agent_instance_to_pickle is None:
         raise ValueError("Error: The root_agent in platform_mcp_client.agent is None. Ensure it's initialized.")
 


### PR DESCRIPTION
The deployment script for platform_mcp_client was attempting to import `agent.root_agent` from the `agents.platform_mcp_client` package. However, the `__init__.py` in that package had an erroneous `from . import agent` statement, and no `agent.py` or `root_agent` instance was correctly defined at the package level.

This change corrects `agents/platform_mcp_client/__init__.py` to import `PlatformAgent` from `.platform_agent` and instantiate it as `root_agent`. The `deploy.py` script for this agent is updated to import this `root_agent` directly.

Docs: Add deployment logic analysis

Adds an `ANALYSIS.md` file to document the findings regarding the agent deployment mechanisms.

The analysis concludes:
- Deployment logic to Vertex AI Reasoning Engines is not stubbed-out.
- LangGraph applications are deployed via wrapper classes, not directly.
- If "Vertex AI Agent Engines" have different requirements than Reasoning Engines (which are currently used), further wrappers or platform-specific SDK integration would be needed.