### PR TITLE
Refactor deploy_all.py to support individual component deployment

### DIFF
--- a/deploy_all.py
+++ b/deploy_all.py
@@ -516,12 +516,27 @@ def main(argv=None):
         print(f"Changed directory back to {original_cwd}.")
     print("Spanner setup completed.")
 
-    parser = argparse.ArgumentParser(description="Deploy all components of the instavibe app.")
-    parser.add_argument("--skip_agents", action="store_true", help="Skip deploying the agents.")
-    parser.add_argument("--skip_app", action="store_true", help="Skip deploying the Instavibe app.")
-    parser.add_argument("--skip_platform_mcp_client", action="store_true", help="Skip deploying the Platform MCP Client.")
-    parser.add_argument("--skip_mcp_tool_server", action="store_true", help="Skip deploying the MCP Tool Server.")
+    parser = argparse.ArgumentParser(description="Deploy components of the instavibe app. If no specific component flags are provided, all components will be deployed.")
+    parser.add_argument("--deploy_instavibe", action="store_true", help="Deploy the Instavibe app.")
+    parser.add_argument("--deploy_mcp_tool_server", action="store_true", help="Deploy the MCP Tool Server.")
+    parser.add_argument("--deploy_agents", action="store_true", help="Deploy all agents (Planner, Social, Orchestrate, Platform MCP Client).")
+    # Add individual agent deployment flags if needed in future, e.g.:
+    # parser.add_argument("--deploy_planner_agent", action="store_true", help="Deploy the Planner agent.")
+    # parser.add_argument("--deploy_social_agent", action="store_true", help="Deploy the Social agent.")
+    # parser.add_argument("--deploy_orchestrate_agent", action="store_true", help="Deploy the Orchestrate agent.")
+    # parser.add_argument("--deploy_platform_mcp_client_agent", action="store_true", help="Deploy the Platform MCP Client agent.")
+
     args = parser.parse_args(argv)
+
+    # Determine if any specific deployment flag was passed
+    specific_deployment_requested = any([
+        args.deploy_instavibe,
+        args.deploy_mcp_tool_server,
+        args.deploy_agents
+    ])
+
+    # If no specific deployment flag is set, default to deploying all
+    deploy_all_components = not specific_deployment_requested
 
     print(f"Initializing Vertex AI with project: {project_id}, region: {region}, staging bucket: {staging_bucket_uri}")
     try:
@@ -533,39 +548,36 @@ def main(argv=None):
 
     planner_resource_name, social_resource_name, platform_mcp_client_resource_name, orchestrate_resource_name = None, None, None, None
 
-    if not args.skip_agents:
+    # Deploy Agents if requested or if deploying all
+    if deploy_all_components or args.deploy_agents:
+        print("--- Deploying Agents ---")
         print("--- Deploying Individual Agents (Planner, Social) ---")
         planner_resource_name = deploy_planner_agent(project_id, region)
-        print(f"DIAGNOSTIC_TRACE: main() - planner_resource_name: '{planner_resource_name}' (type: {type(planner_resource_name)})") # DIAGNOSTIC_TRACE
+        print(f"DIAGNOSTIC_TRACE: main() - planner_resource_name: '{planner_resource_name}' (type: {type(planner_resource_name)})")
         social_resource_name = deploy_social_agent(project_id, region)
-        print(f"DIAGNOSTIC_TRACE: main() - social_resource_name: '{social_resource_name}' (type: {type(social_resource_name)})") # DIAGNOSTIC_TRACE
-    else:
-        print("Skipping Planner and Social agent deployments due to --skip_agents flag.")
+        print(f"DIAGNOSTIC_TRACE: main() - social_resource_name: '{social_resource_name}' (type: {type(social_resource_name)})")
 
-    if not args.skip_platform_mcp_client: # Not skipped by --skip_agents, has its own flag
         print("--- Deploying Platform MCP Client Agent ---")
         platform_mcp_client_resource_name = deploy_platform_mcp_client(project_id, region)
-        print(f"DIAGNOSTIC_TRACE: main() - platform_mcp_client_resource_name: '{platform_mcp_client_resource_name}' (type: {type(platform_mcp_client_resource_name)})") # DIAGNOSTIC_TRACE
-    else:
-        print("Skipping Platform MCP Client agent deployment due to --skip_platform_mcp_client flag.")
+        print(f"DIAGNOSTIC_TRACE: main() - platform_mcp_client_resource_name: '{platform_mcp_client_resource_name}' (type: {type(platform_mcp_client_resource_name)})")
 
-    # DIAGNOSTIC_TRACE: Log contents of valid_remote_agent_names before join
-    temp_remote_names_for_debug = [planner_resource_name, social_resource_name, platform_mcp_client_resource_name]
-    print(f"DIAGNOSTIC_TRACE: main() - Names for orchestrator_dynamic_addresses before filtering: {temp_remote_names_for_debug}")
-    valid_remote_agent_names = [name for name in temp_remote_names_for_debug if name]
-    print(f"DIAGNOSTIC_TRACE: main() - Valid names for orchestrator_dynamic_addresses after filtering: {valid_remote_agent_names}")
-    orchestrator_dynamic_addresses = ",".join(valid_remote_agent_names)
-    print(f"DIAGNOSTIC_TRACE: main() - orchestrator_dynamic_addresses: '{orchestrator_dynamic_addresses}'") # DIAGNOSTIC_TRACE
+        # DIAGNOSTIC_TRACE: Log contents of valid_remote_agent_names before join
+        temp_remote_names_for_debug = [planner_resource_name, social_resource_name, platform_mcp_client_resource_name]
+        print(f"DIAGNOSTIC_TRACE: main() - Names for orchestrator_dynamic_addresses before filtering: {temp_remote_names_for_debug}")
+        valid_remote_agent_names = [name for name in temp_remote_names_for_debug if name]
+        print(f"DIAGNOSTIC_TRACE: main() - Valid names for orchestrator_dynamic_addresses after filtering: {valid_remote_agent_names}")
+        orchestrator_dynamic_addresses = ",".join(valid_remote_agent_names)
+        print(f"DIAGNOSTIC_TRACE: main() - orchestrator_dynamic_addresses: '{orchestrator_dynamic_addresses}'")
 
-
-    if not args.skip_agents: # Orchestrator is skipped if all agents are skipped
         print("--- Deploying Orchestrate Agent ---")
         orchestrate_resource_name = deploy_orchestrate_agent(project_id, region, remote_addresses_str=orchestrator_dynamic_addresses)
-        print(f"DIAGNOSTIC_TRACE: main() - orchestrate_resource_name: '{orchestrate_resource_name}' (type: {type(orchestrate_resource_name)})") # DIAGNOSTIC_TRACE
+        print(f"DIAGNOSTIC_TRACE: main() - orchestrate_resource_name: '{orchestrate_resource_name}' (type: {type(orchestrate_resource_name)})")
     else:
-        print("Skipping Orchestrate agent deployment due to --skip_agents flag.")
+        print("Skipping agent deployments as neither --deploy_agents nor default all deployment was specified.")
 
-    if not args.skip_app:
+    # Deploy Instavibe App if requested or if deploying all
+    if deploy_all_components or args.deploy_instavibe:
+        print("--- Deploying Instavibe App ---")
         instavibe_env_vars_list = [
             f"COMMON_GOOGLE_CLOUD_PROJECT={project_id}",
             f"COMMON_SPANNER_INSTANCE_ID={spanner_instance_id}",
@@ -583,12 +595,14 @@ def main(argv=None):
         if orchestrate_resource_name: instavibe_env_vars_list.append(f"AGENTS_ORCHESTRATE_RESOURCE_NAME={orchestrate_resource_name}")
 
         instavibe_env_vars_string = ",".join(var for var in instavibe_env_vars_list if var.split('=', 1)[1]) # Ensure value is not empty
-        print(f"DEBUG: instavibe_env_vars_string for instavibe-app: '{instavibe_env_vars_string}'") # ADDED FOR DEBUGGING
+        print(f"DEBUG: instavibe_env_vars_string for instavibe-app: '{instavibe_env_vars_string}'")
         deploy_instavibe_app(project_id, region, env_vars_string=instavibe_env_vars_string)
     else:
-        print("Skipping Instavibe app deployment.")
+        print("Skipping Instavibe app deployment as --deploy_instavibe was not specified and not deploying all.")
 
-    if not args.skip_mcp_tool_server:
+    # Deploy MCP Tool Server if requested or if deploying all
+    if deploy_all_components or args.deploy_mcp_tool_server:
+        print("--- Deploying MCP Tool Server ---")
         mcp_tool_server_env_vars_list = [
             f"COMMON_GOOGLE_CLOUD_PROJECT={project_id}",
             f"TOOLS_INSTAVIBE_BASE_URL={sanitize_env_var_value(os.environ.get('TOOLS_INSTAVIBE_BASE_URL', ''))}",
@@ -597,10 +611,10 @@ def main(argv=None):
             f"TOOLS_GOOGLE_API_KEY={sanitize_env_var_value(os.environ.get('TOOLS_GOOGLE_API_KEY', ''))}"
         ]
         mcp_tool_server_env_vars_string = ",".join(var for var in mcp_tool_server_env_vars_list if var.split('=', 1)[1])
-        print(f"DEBUG: mcp_tool_server_env_vars_string for mcp-tool-server: '{mcp_tool_server_env_vars_string}'") # ADDED FOR DEBUGGING
+        print(f"DEBUG: mcp_tool_server_env_vars_string for mcp-tool-server: '{mcp_tool_server_env_vars_string}'")
         deploy_mcp_tool_server(project_id, region, env_vars_string=mcp_tool_server_env_vars_string if mcp_tool_server_env_vars_string else None)
     else:
-        print("Skipping MCP Tool Server deployment.")
+        print("Skipping MCP Tool Server deployment as --deploy_mcp_tool_server was not specified and not deploying all.")
 
     print("All selected components deployed.")
 

--- a/test_deploy_all.py
+++ b/test_deploy_all.py
@@ -199,129 +199,252 @@ class TestDeployAllScript(unittest.TestCase):
         mock_planner_main_func.assert_not_called()
 
     # Tests for main() function and argument parsing
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env', 'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env', 'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env'}, clear=True)
+    @patch('deploy_all.vertexai.init')
+    @patch('deploy_all.build_a2a_common_wheel')
+    @patch('deploy_all.load_dotenv')
+    @patch.dict(os.environ, {
+        'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env',
+        'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env',
+        'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env',
+        'COMMON_SPANNER_INSTANCE_ID': 'test-spanner-instance',
+        'COMMON_SPANNER_DATABASE_ID': 'test-spanner-db',
+        'INSTAVIBE_FLASK_SECRET_KEY': 'test-secret',
+        # Add other necessary env vars for the functions being called if they rely on them directly
+    }, clear=True)
+    @patch('deploy_all.subprocess.run') # Mock subprocess globally for Spanner setup etc.
     @patch('deploy_all.deploy_mcp_tool_server')
     @patch('deploy_all.deploy_instavibe_app')
     @patch('deploy_all.deploy_platform_mcp_client')
     @patch('deploy_all.deploy_orchestrate_agent')
     @patch('deploy_all.deploy_social_agent')
     @patch('deploy_all.deploy_planner_agent')
-    def test_main_default_behavior(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool):
-        # The arguments to deploy_all.main are now ignored as project_id and region come from env vars
-        deploy_all.main([]) # Pass empty list as args are parsed but values from env are used first
+    def test_main_default_behavior_deploys_all(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool, mock_spanner_subprocess, mock_load_dotenv, mock_build_wheel, mock_vertex_init):
+        # Ensure subprocess.run for spanner doesn't fail tests
+        mock_spanner_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
-        # Assertions should now use the env var values
+        mock_planner.return_value = "planner-id"
+        mock_social.return_value = "social-id"
+        mock_platform_mcp.return_value = "platform-mcp-id"
+        mock_orchestrate.return_value = "orchestrate-id"
+
+        deploy_all.main([]) # No args means deploy all
+
+        mock_vertex_init.assert_called_once_with(project='test-p-env', location='test-r-env', staging_bucket='gs://test-bucket-env')
+        mock_build_wheel.assert_called_once()
+        mock_load_dotenv.assert_called_once()
+
         mock_planner.assert_called_once_with('test-p-env', 'test-r-env')
         mock_social.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env')
+        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env', remote_addresses_str="planner-id,social-id,platform-mcp-id")
         mock_platform_mcp.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,INSTAVIBE_APP_HOST=0.0.0.0,INSTAVIBE_APP_PORT=8080')
-        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env')
 
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env', 'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env', 'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env'}, clear=True)
+        expected_instavibe_env_vars = [
+            "COMMON_GOOGLE_CLOUD_PROJECT=test-p-env",
+            "COMMON_SPANNER_INSTANCE_ID=test-spanner-instance",
+            "COMMON_SPANNER_DATABASE_ID=test-spanner-db",
+            "INSTAVIBE_FLASK_SECRET_KEY=test-secret", # from env
+            "INSTAVIBE_APP_HOST=0.0.0.0", # default
+            "INSTAVIBE_APP_PORT=8080", # default
+            # INSTAVIBE_GOOGLE_MAPS_API_KEY and MAP_ID might be empty if not in env
+            "COMMON_GOOGLE_CLOUD_LOCATION=test-r-env",
+            "AGENTS_PLANNER_RESOURCE_NAME=planner-id",
+            "AGENTS_SOCIAL_RESOURCE_NAME=social-id",
+            "AGENTS_PLATFORM_MCP_CLIENT_RESOURCE_NAME=platform-mcp-id",
+            "AGENTS_ORCHESTRATE_RESOURCE_NAME=orchestrate-id"
+        ]
+        # Filter out vars with empty values as deploy_all.py does
+        expected_instavibe_env_string = ",".join(var for var in expected_instavibe_env_vars if var.split('=',1)[1])
+
+        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string=expected_instavibe_env_string)
+
+        expected_mcp_tool_env_vars = [
+            "COMMON_GOOGLE_CLOUD_PROJECT=test-p-env",
+            # TOOLS_INSTAVIBE_BASE_URL might be empty
+            "TOOLS_GOOGLE_GENAI_USE_VERTEXAI=True", # default
+            "TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env"
+            # TOOLS_GOOGLE_API_KEY might be empty
+        ]
+        expected_mcp_tool_env_string = ",".join(var for var in expected_mcp_tool_env_vars if var.split('=',1)[1])
+        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string=expected_mcp_tool_env_string)
+
+
+    @patch('deploy_all.vertexai.init')
+    @patch('deploy_all.build_a2a_common_wheel')
+    @patch('deploy_all.load_dotenv')
+    @patch.dict(os.environ, {
+        'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env',
+        'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env',
+        'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env',
+        'COMMON_SPANNER_INSTANCE_ID': 'test-spanner-instance',
+        'COMMON_SPANNER_DATABASE_ID': 'test-spanner-db',
+        'INSTAVIBE_FLASK_SECRET_KEY': 'test-secret',
+    }, clear=True)
+    @patch('deploy_all.subprocess.run')
     @patch('deploy_all.deploy_mcp_tool_server')
     @patch('deploy_all.deploy_instavibe_app')
     @patch('deploy_all.deploy_platform_mcp_client')
     @patch('deploy_all.deploy_orchestrate_agent')
     @patch('deploy_all.deploy_social_agent')
     @patch('deploy_all.deploy_planner_agent')
-    def test_main_skip_agents(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool):
-        deploy_all.main(['--skip_agents']) # project_id and region from env
+    def test_main_deploy_agents_only(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool, mock_spanner_subprocess, mock_load_dotenv, mock_build_wheel, mock_vertex_init):
+        mock_spanner_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        mock_planner.return_value = "p"
+        mock_social.return_value = "s"
+        mock_platform_mcp.return_value = "pmcp"
+
+        deploy_all.main(['--deploy_agents'])
+
+        mock_planner.assert_called_once_with('test-p-env', 'test-r-env')
+        mock_social.assert_called_once_with('test-p-env', 'test-r-env')
+        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env', remote_addresses_str="p,s,pmcp")
+        mock_platform_mcp.assert_called_once_with('test-p-env', 'test-r-env')
+
+        mock_instavibe.assert_not_called()
+        mock_mcp_tool.assert_not_called()
+
+    @patch('deploy_all.vertexai.init')
+    @patch('deploy_all.build_a2a_common_wheel')
+    @patch('deploy_all.load_dotenv')
+    @patch.dict(os.environ, {
+        'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env',
+        'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env',
+        'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env',
+        'COMMON_SPANNER_INSTANCE_ID': 'test-spanner-instance',
+        'COMMON_SPANNER_DATABASE_ID': 'test-spanner-db',
+        'INSTAVIBE_FLASK_SECRET_KEY': 'test-secret',
+    }, clear=True)
+    @patch('deploy_all.subprocess.run')
+    @patch('deploy_all.deploy_mcp_tool_server')
+    @patch('deploy_all.deploy_instavibe_app')
+    @patch('deploy_all.deploy_platform_mcp_client')
+    @patch('deploy_all.deploy_orchestrate_agent')
+    @patch('deploy_all.deploy_social_agent')
+    @patch('deploy_all.deploy_planner_agent')
+    def test_main_deploy_instavibe_only(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool, mock_spanner_subprocess, mock_load_dotenv, mock_build_wheel, mock_vertex_init):
+        mock_spanner_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        deploy_all.main(['--deploy_instavibe'])
 
         mock_planner.assert_not_called()
         mock_social.assert_not_called()
         mock_orchestrate.assert_not_called()
-        # As per deploy_all.py logic, if --skip_agents is true,
-        # deploy_planner_agent, deploy_social_agent, deploy_orchestrate_agent are skipped.
-        # deploy_platform_mcp_client is skipped by its own flag --skip_platform_mcp_client.
-        # So, platform_mcp, instavibe, mcp_tool should still be called if their flags are not set.
-        mock_platform_mcp.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,INSTAVIBE_APP_HOST=0.0.0.0,INSTAVIBE_APP_PORT=8080')
-        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env')
-
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env', 'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env', 'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env'}, clear=True)
-    @patch('deploy_all.deploy_mcp_tool_server')
-    @patch('deploy_all.deploy_instavibe_app')
-    @patch('deploy_all.deploy_platform_mcp_client')
-    @patch('deploy_all.deploy_orchestrate_agent')
-    @patch('deploy_all.deploy_social_agent')
-    @patch('deploy_all.deploy_planner_agent')
-    def test_main_skip_app(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool):
-        deploy_all.main(['--skip_app']) # project_id and region from env
-
-        mock_planner.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_social.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_platform_mcp.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_instavibe.assert_not_called()
-        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env')
-
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env', 'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env', 'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env'}, clear=True)
-    @patch('deploy_all.deploy_mcp_tool_server')
-    @patch('deploy_all.deploy_instavibe_app')
-    @patch('deploy_all.deploy_platform_mcp_client')
-    @patch('deploy_all.deploy_orchestrate_agent')
-    @patch('deploy_all.deploy_social_agent')
-    @patch('deploy_all.deploy_planner_agent')
-    def test_main_skip_platform_mcp_client(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool):
-        deploy_all.main(['--skip_platform_mcp_client']) # project_id and region from env
-
-        mock_planner.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_social.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env')
         mock_platform_mcp.assert_not_called()
-        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,INSTAVIBE_APP_HOST=0.0.0.0,INSTAVIBE_APP_PORT=8080')
-        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env')
 
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env', 'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env', 'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env'}, clear=True)
-    @patch('deploy_all.deploy_mcp_tool_server')
-    @patch('deploy_all.deploy_instavibe_app')
-    @patch('deploy_all.deploy_platform_mcp_client')
-    @patch('deploy_all.deploy_orchestrate_agent')
-    @patch('deploy_all.deploy_social_agent')
-    @patch('deploy_all.deploy_planner_agent')
-    def test_main_skip_mcp_tool_server(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool):
-        deploy_all.main(['--skip_mcp_tool_server']) # project_id and region from env
-
-        mock_planner.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_social.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_platform_mcp.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,INSTAVIBE_APP_HOST=0.0.0.0,INSTAVIBE_APP_PORT=8080')
+        expected_instavibe_env_vars = [
+            "COMMON_GOOGLE_CLOUD_PROJECT=test-p-env",
+            "COMMON_SPANNER_INSTANCE_ID=test-spanner-instance",
+            "COMMON_SPANNER_DATABASE_ID=test-spanner-db",
+            "INSTAVIBE_FLASK_SECRET_KEY=test-secret",
+            "INSTAVIBE_APP_HOST=0.0.0.0",
+            "INSTAVIBE_APP_PORT=8080",
+            "COMMON_GOOGLE_CLOUD_LOCATION=test-r-env",
+            # Agent names will be missing as they are not deployed
+        ]
+        expected_instavibe_env_string = ",".join(var for var in expected_instavibe_env_vars if var.split('=',1)[1])
+        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string=expected_instavibe_env_string)
         mock_mcp_tool.assert_not_called()
 
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env', 'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env', 'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env'}, clear=True)
+    @patch('deploy_all.vertexai.init')
+    @patch('deploy_all.build_a2a_common_wheel')
+    @patch('deploy_all.load_dotenv')
+    @patch.dict(os.environ, {
+        'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env',
+        'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env',
+        'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env',
+        'COMMON_SPANNER_INSTANCE_ID': 'test-spanner-instance',
+        'COMMON_SPANNER_DATABASE_ID': 'test-spanner-db',
+    }, clear=True)
+    @patch('deploy_all.subprocess.run')
     @patch('deploy_all.deploy_mcp_tool_server')
     @patch('deploy_all.deploy_instavibe_app')
     @patch('deploy_all.deploy_platform_mcp_client')
     @patch('deploy_all.deploy_orchestrate_agent')
     @patch('deploy_all.deploy_social_agent')
     @patch('deploy_all.deploy_planner_agent')
-    def test_main_skip_app_and_skip_social_and_skip_platform_mcp(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool):
-        # Testing a combination.
-        # --skip_social_agent is not an existing flag. --skip_agents will skip social.
-        # This test will skip app and platform_mcp_client. Social agent should still run.
-        args = ['--skip_app', '--skip_platform_mcp_client'] # project_id and region from env
-        deploy_all.main(args)
+    def test_main_deploy_mcp_tool_server_only(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool, mock_spanner_subprocess, mock_load_dotenv, mock_build_wheel, mock_vertex_init):
+        mock_spanner_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        deploy_all.main(['--deploy_mcp_tool_server'])
+
+        mock_planner.assert_not_called()
+        mock_social.assert_not_called()
+        mock_orchestrate.assert_not_called()
+        mock_platform_mcp.assert_not_called()
+        mock_instavibe.assert_not_called()
+
+        expected_mcp_tool_env_vars = [
+            "COMMON_GOOGLE_CLOUD_PROJECT=test-p-env",
+            "TOOLS_GOOGLE_GENAI_USE_VERTEXAI=True",
+            "TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env"
+        ]
+        expected_mcp_tool_env_string = ",".join(var for var in expected_mcp_tool_env_vars if var.split('=',1)[1])
+        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string=expected_mcp_tool_env_string)
+
+    @patch('deploy_all.vertexai.init')
+    @patch('deploy_all.build_a2a_common_wheel')
+    @patch('deploy_all.load_dotenv')
+    @patch.dict(os.environ, {
+        'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env',
+        'COMMON_GOOGLE_CLOUD_LOCATION': 'test-r-env',
+        'COMMON_VERTEX_STAGING_BUCKET': 'gs://test-bucket-env',
+        'COMMON_SPANNER_INSTANCE_ID': 'test-spanner-instance',
+        'COMMON_SPANNER_DATABASE_ID': 'test-spanner-db',
+        'INSTAVIBE_FLASK_SECRET_KEY': 'test-secret',
+    }, clear=True)
+    @patch('deploy_all.subprocess.run')
+    @patch('deploy_all.deploy_mcp_tool_server')
+    @patch('deploy_all.deploy_instavibe_app')
+    @patch('deploy_all.deploy_platform_mcp_client')
+    @patch('deploy_all.deploy_orchestrate_agent')
+    @patch('deploy_all.deploy_social_agent')
+    @patch('deploy_all.deploy_planner_agent')
+    def test_main_deploy_instavibe_and_agents(self, mock_planner, mock_social, mock_orchestrate, mock_platform_mcp, mock_instavibe, mock_mcp_tool, mock_spanner_subprocess, mock_load_dotenv, mock_build_wheel, mock_vertex_init):
+        mock_spanner_subprocess.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        mock_planner.return_value = "p-id"
+        mock_social.return_value = "s-id"
+        mock_platform_mcp.return_value = "pmcp-id"
+        mock_orchestrate.return_value = "o-id"
+
+        deploy_all.main(['--deploy_instavibe', '--deploy_agents'])
 
         mock_planner.assert_called_once_with('test-p-env', 'test-r-env')
         mock_social.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env')
-        mock_platform_mcp.assert_not_called()
-        mock_instavibe.assert_not_called()
-        mock_mcp_tool.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string='COMMON_GOOGLE_CLOUD_PROJECT=test-p-env,TOOLS_GOOGLE_CLOUD_LOCATION=test-r-env')
+        mock_orchestrate.assert_called_once_with('test-p-env', 'test-r-env', remote_addresses_str="p-id,s-id,pmcp-id")
+        mock_platform_mcp.assert_called_once_with('test-p-env', 'test-r-env')
+
+        expected_instavibe_env_vars = [
+            "COMMON_GOOGLE_CLOUD_PROJECT=test-p-env",
+            "COMMON_SPANNER_INSTANCE_ID=test-spanner-instance",
+            "COMMON_SPANNER_DATABASE_ID=test-spanner-db",
+            "INSTAVIBE_FLASK_SECRET_KEY=test-secret",
+            "INSTAVIBE_APP_HOST=0.0.0.0",
+            "INSTAVIBE_APP_PORT=8080",
+            "COMMON_GOOGLE_CLOUD_LOCATION=test-r-env",
+            "AGENTS_PLANNER_RESOURCE_NAME=p-id",
+            "AGENTS_SOCIAL_RESOURCE_NAME=s-id",
+            "AGENTS_PLATFORM_MCP_CLIENT_RESOURCE_NAME=pmcp-id",
+            "AGENTS_ORCHESTRATE_RESOURCE_NAME=o-id"
+        ]
+        expected_instavibe_env_string = ",".join(var for var in expected_instavibe_env_vars if var.split('=',1)[1])
+        mock_instavibe.assert_called_once_with('test-p-env', 'test-r-env', env_vars_string=expected_instavibe_env_string)
+
+        mock_mcp_tool.assert_not_called()
+
 
     @patch.dict(os.environ, {}, clear=True) # Test with NO env vars set
-    def test_main_missing_project_id(self):
-        with self.assertRaises(ValueError) as context: # Expect ValueError from os.environ.get checks
-            deploy_all.main([]) # Args don't matter, will fail on env var check
-        self.assertIn("COMMON_GOOGLE_CLOUD_PROJECT not set", str(context.exception))
+    @patch('deploy_all.load_dotenv') # Mock load_dotenv as it's called early
+    @patch('deploy_all.build_a2a_common_wheel') # Mock build_a2a_common_wheel
+    def test_main_missing_env_vars_raises_value_error(self, mock_build_wheel, mock_load_dotenv):
+        mock_load_dotenv.return_value = None # Simulate .env not loading anything critical for this check
+        mock_build_wheel.return_value = None # Simulate successful wheel build
 
-    @patch.dict(os.environ, {'COMMON_GOOGLE_CLOUD_PROJECT': 'test-p-env'}, clear=True) # Test with only project set
-    def test_main_missing_region(self):
         with self.assertRaises(ValueError) as context:
             deploy_all.main([])
-        self.assertIn("COMMON_GOOGLE_CLOUD_LOCATION (used as common deploy region) not set", str(context.exception))
+        self.assertIn("Missing critical environment variables", str(context.exception))
+        self.assertIn("COMMON_GOOGLE_CLOUD_PROJECT", str(context.exception))
+        self.assertIn("COMMON_GOOGLE_CLOUD_LOCATION", str(context.exception))
+        self.assertIn("COMMON_VERTEX_STAGING_BUCKET", str(context.exception))
+        self.assertIn("COMMON_SPANNER_INSTANCE_ID", str(context.exception))
+        self.assertIn("COMMON_SPANNER_DATABASE_ID", str(context.exception))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change modifies the `deploy_all.py` script to allow users to deploy specific components (Instavibe, MCP Tool Server, Agents) individually using new command-line flags:

- `--deploy_instavibe`
- `--deploy_mcp_tool_server`
- `--deploy_agents`

If no specific deployment flags are provided, the script defaults to deploying all components, preserving the original behavior.

The previous `--skip_` arguments have been removed in favor of this more direct approach.

Unit tests in `test_deploy_all.py` have been updated to reflect these changes, including new test cases for individual and combined deployments, and adjustments to mocks for initialization steps.