### PR TITLE
refactor(orchestrate): Update deprecated gemini-1.5-flash model

### DIFF
--- a/agents/orchestrate/orchestrate_service_agent.py
+++ b/agents/orchestrate/orchestrate_service_agent.py
@@ -134,5 +134,5 @@ OrchestrateServiceAgent.model_rebuild()
 
 root_agent = OrchestrateServiceAgent(
     name="orchestrate_service_agent",
-    model="gemini-1.5-flash"
+    model="gemini-2.0-flash-001"
 )


### PR DESCRIPTION
The `gemini-1.5-flash` model is deprecated and was causing issues.

This commit updates the model used by the `OrchestrateServiceAgent` from `gemini-1.5-flash-001` to `gemini-2.0-flash-001` to use a non-deprecated model and align with the other agents in the codebase.